### PR TITLE
fix(ts): drop explicit pnpm version in release-ts.yml

### DIFF
--- a/.github/workflows/release-ts.yml
+++ b/.github/workflows/release-ts.yml
@@ -25,8 +25,6 @@ jobs:
           fetch-depth: 0
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - uses: actions/setup-node@v5
         with:
@@ -74,8 +72,6 @@ jobs:
           persist-credentials: false
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - uses: actions/setup-node@v5
         with:


### PR DESCRIPTION
pnpm/action-setup@v4 errors when both `version:` input and package.json `packageManager` are set. Drop the input so the action honors `packageManager: pnpm@9.14.4` as the single source of truth.