### PR TITLE
fix: stabilize CI — timing tolerance + TS release OIDC

### DIFF
--- a/.github/workflows/release-ts.yml
+++ b/.github/workflows/release-ts.yml
@@ -101,15 +101,16 @@ jobs:
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Semantic release
+      - name: Semantic release (tag + version bump + changelog, skip npm publish)
         id: release
         if: steps.check.outputs.has_changes == 'true' || inputs.force_publish == true
         working-directory: packages/statuspro-client
         env:
           GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
-          NPM_CONFIG_PROVENANCE: "true"
         run: |
-          # Capture semantic-release output so callers can read outputs.
+          # @semantic-release/npm is configured with npmPublish: false, so this
+          # step only runs analyzeCommits → version bump → tag → GitHub release.
+          # The actual npm publish happens in the next step via OIDC.
           OUTPUT=$(npx semantic-release 2>&1) || {
             EXIT=$?
             echo "$OUTPUT"
@@ -123,3 +124,13 @@ jobs:
           else
             echo "new_release_published=false" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Publish to npm via OIDC Trusted Publisher
+        if: steps.release.outputs.new_release_published == 'true'
+        working-directory: packages/statuspro-client
+        env:
+          NPM_CONFIG_PROVENANCE: "true"
+        run: |
+          # Uses GitHub Actions OIDC — no NPM_TOKEN required.
+          # Requires Trusted Publisher configured on npmjs.com for this package + workflow.
+          pnpm publish --no-git-checks --access public

--- a/packages/statuspro-client/.releaserc.json
+++ b/packages/statuspro-client/.releaserc.json
@@ -49,6 +49,7 @@
       "@semantic-release/npm",
       {
         "pkgRoot": ".",
+        "npmPublish": false,
         "tarballDir": "dist-npm"
       }
     ],

--- a/statuspro_mcp_server/tests/test_observability_decorators.py
+++ b/statuspro_mcp_server/tests/test_observability_decorators.py
@@ -268,11 +268,12 @@ async def test_observe_service_timing_accuracy(setup_test_logging):
         service = TestService()
         await service.slow_method()
 
-        # Check that duration is roughly 50ms or more
+        # Check that duration is roughly 50ms or more. Upper bound is generous
+        # because shared CI runners occasionally add 50-100ms of scheduling jitter.
         completed_call = mock_logger.debug.call_args_list[1]
         duration_ms = completed_call[1]["duration_ms"]
-        assert duration_ms >= 50  # Should be at least 50ms
-        assert duration_ms < 100  # But not too much more (with some tolerance)
+        assert duration_ms >= 50  # Should be at least 50ms (asyncio.sleep guarantee)
+        assert duration_ms < 500  # Room for CI jitter; still proves timing is measured
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- **Timing test**: bump upper bound 100ms → 500ms. CI scheduling jitter was causing sporadic failures (last run: 109ms on a 50ms-sleep test).
- **TS release**: split `@semantic-release/npm` (now `npmPublish: false`) from the actual publish step. Added explicit `pnpm publish --provenance` that uses OIDC, no NPM_TOKEN needed.

## Test plan

- [x] Local `uv run poe check` green
- [ ] CI green on this PR
- [ ] Next `main` push: Release TS Client workflow reaches the publish step (will fail until npm Trusted Publisher is configured — that's expected, final blocker is registry-side config)
