### PR TITLE
fix(ts): migrate biome config to v2 schema

### DIFF
--- a/packages/statuspro-client/biome.json
+++ b/packages/statuspro-client/biome.json
@@ -1,8 +1,6 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
-  "organizeImports": {
-    "enabled": true
-  },
+  "$schema": "https://biomejs.dev/schemas/2.4.12/schema.json",
+  "assist": { "actions": { "source": { "organizeImports": "on" } } },
   "linter": {
     "enabled": true,
     "rules": {
@@ -27,6 +25,6 @@
     }
   },
   "files": {
-    "ignore": ["dist", "node_modules", "src/generated"]
+    "includes": ["**", "!**/dist", "!**/node_modules", "!**/src/generated"]
   }
 }

--- a/packages/statuspro-client/src/client.ts
+++ b/packages/statuspro-client/src/client.ts
@@ -8,14 +8,14 @@
 import { createClient, createConfig } from './generated/client/index.js';
 import type { Client } from './generated/client/types.gen.js';
 import {
+  createPaginatedFetch,
   DEFAULT_PAGINATION_CONFIG,
   type PaginationConfig,
-  createPaginatedFetch,
 } from './transport/pagination.js';
 import {
+  createResilientFetch,
   DEFAULT_RETRY_CONFIG,
   type RetryConfig,
-  createResilientFetch,
 } from './transport/resilient.js';
 
 /**

--- a/packages/statuspro-client/src/index.ts
+++ b/packages/statuspro-client/src/index.ts
@@ -27,35 +27,31 @@ export { StatusProClient, type StatusProClientOptions } from './client.js';
 
 // Re-export error types and utilities
 export {
-  StatusProError,
   AuthenticationError,
-  RateLimitError,
-  ValidationError,
-  ServerError,
   NetworkError,
   parseError,
+  RateLimitError,
+  ServerError,
+  StatusProError,
+  ValidationError,
   type ValidationErrorDetail,
 } from './errors.js';
-
+// Re-export the Client type for advanced usage
+export type { Client } from './generated/client/types.gen.js';
+// Re-export generated SDK functions for direct API access
+export * from './generated/sdk.gen.js';
+export {
+  createPaginatedFetch,
+  DEFAULT_PAGINATION_CONFIG,
+  type PaginatedResponse,
+  type PaginationConfig,
+} from './transport/pagination.js';
 // Re-export transport utilities for advanced usage
 export {
   createResilientFetch,
-  type RetryConfig,
   DEFAULT_RETRY_CONFIG,
+  type RetryConfig,
 } from './transport/resilient.js';
-
-export {
-  createPaginatedFetch,
-  type PaginationConfig,
-  DEFAULT_PAGINATION_CONFIG,
-  type PaginatedResponse,
-} from './transport/pagination.js';
-
-// Re-export generated SDK functions for direct API access
-export * from './generated/sdk.gen.js';
-
-// Re-export the Client type for advanced usage
-export type { Client } from './generated/client/types.gen.js';
 
 // Re-export all generated types for convenience
 export * from './types.js';

--- a/packages/statuspro-client/tests/client.test.ts
+++ b/packages/statuspro-client/tests/client.test.ts
@@ -35,7 +35,6 @@ describe('StatusProClient', () => {
     it('should throw descriptive error when no API key is available', async () => {
       // Temporarily remove env var if present
       const originalEnv = process.env.STATUSPRO_API_KEY;
-      // biome-ignore lint/performance/noDelete: Need to actually remove env var, not set to "undefined" string
       delete process.env.STATUSPRO_API_KEY;
 
       try {
@@ -61,7 +60,6 @@ describe('StatusProClient', () => {
         if (originalEnv) {
           process.env.STATUSPRO_API_KEY = originalEnv;
         } else {
-          // biome-ignore lint/performance/noDelete: Need to actually remove env var, not set to "undefined" string
           delete process.env.STATUSPRO_API_KEY;
         }
       }

--- a/packages/statuspro-client/tests/errors.test.ts
+++ b/packages/statuspro-client/tests/errors.test.ts
@@ -6,11 +6,11 @@ import { describe, expect, it } from 'vitest';
 import {
   AuthenticationError,
   NetworkError,
+  parseError,
   RateLimitError,
   ServerError,
   StatusProError,
   ValidationError,
-  parseError,
 } from '../src/errors.js';
 
 describe('Error Classes', () => {

--- a/packages/statuspro-client/tests/transport/retry.test.ts
+++ b/packages/statuspro-client/tests/transport/retry.test.ts
@@ -6,9 +6,9 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
-  DEFAULT_RETRY_CONFIG,
   calculateRetryDelay,
   createResilientFetch,
+  DEFAULT_RETRY_CONFIG,
   shouldRetry,
 } from '../../src/transport/resilient.js';
 


### PR DESCRIPTION
Biome 2.4 renamed `files.ignore` to `files.includes` with negative globs. Ran `biome migrate --write` and dropped two unused `noDelete` suppressions. Lint + tests (104/104) green locally.