### PR TITLE
fix(ts): align tsconfig with TypeScript 6

### DIFF
--- a/packages/statuspro-client/tsconfig.json
+++ b/packages/statuspro-client/tsconfig.json
@@ -2,8 +2,10 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "ESNext",
+    "ignoreDeprecations": "6.0",
     "moduleResolution": "bundler",
     "lib": ["ES2020", "DOM"],
+    "types": ["node"],
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,


### PR DESCRIPTION
Two small TS6 compatibility fixes: add explicit `types: ["node"]` so `process` resolves, and `ignoreDeprecations: "6.0"` to silence tsup's injected `baseUrl` during DTS generation.