### PR TITLE
feat(mcp)!: drop lookup_order tool from MCP surface

### DIFF
--- a/statuspro_mcp_server/src/statuspro_mcp/resources/help.py
+++ b/statuspro_mcp_server/src/statuspro_mcp/resources/help.py
@@ -11,9 +11,8 @@ _HELP_MARKDOWN = """\
 
 | Tool | Endpoint | Purpose |
 | ---- | -------- | ------- |
-| `list_orders` | `GET /orders` | Paginated list with filters (search, status, tags, due-date range). Auto-paginates. |
+| `list_orders` | `GET /orders` | Paginated list with filters (search, status, tags, due-date range). Auto-paginates. `search` matches order number, name, or customer fields — use it to find an order from just an order number. |
 | `get_order` | `GET /orders/{id}` | Full detail for one order, including history. |
-| `lookup_order` | `GET /orders/lookup` | Look up an order by `number` + customer `email`. |
 | `get_viable_statuses` | `GET /orders/{id}/viable-statuses` | Valid status transitions for the order's current state. |
 | `update_order_status` | `POST /orders/{id}/status` | Change status. Two-step confirm. |
 | `add_order_comment` | `POST /orders/{id}/comment` | Add a history comment. Two-step confirm. 5/min. |

--- a/statuspro_mcp_server/src/statuspro_mcp/server.py
+++ b/statuspro_mcp_server/src/statuspro_mcp/server.py
@@ -189,7 +189,7 @@ StatusPro MCP Server — Read and update order status via the StatusPro API.
 ## Tool Selection Guide
 
 **Finding orders:**
-  list_orders (filter by status, date range, tags) | lookup_order (by order number + customer email) | get_order (by id)
+  list_orders (filter by status, date range, tags; `search` matches order number, name, or customer fields) | get_order (by id)
 
 **Changing status:**
   get_viable_statuses → update_order_status
@@ -223,7 +223,6 @@ The client automatically retries with exponential backoff on 429 responses.
 _READ_ONLY_TOOLS = [
     "list_orders",
     "get_order",
-    "lookup_order",
     "list_statuses",
     "get_viable_statuses",
 ]

--- a/statuspro_mcp_server/src/statuspro_mcp/tools/orders.py
+++ b/statuspro_mcp_server/src/statuspro_mcp/tools/orders.py
@@ -1,12 +1,17 @@
 """MCP tools for StatusPro orders.
 
-7 tools mapping to the ``/orders*`` endpoints. Mutations use a two-step confirm
+6 tools mapping to the ``/orders*`` endpoints. Mutations use a two-step confirm
 pattern: call with ``confirm=False`` to see a preview, then ``confirm=True`` to
 execute (the client host elicits explicit user approval via ``ctx.elicit``).
 
 Three tools — ``list_orders``, ``get_order``, ``update_order_status`` — return
 a Prefab UI for MCP-Apps clients (Claude Desktop) via ``make_tool_result`` and
 ``meta=UI_META``. Others return plain Pydantic/dict responses.
+
+The ``GET /orders/lookup`` endpoint is intentionally not exposed: it is the
+public, customer-verification path (requires ``number`` + ``email``) and adds
+nothing for an authenticated MCP caller, who can already use ``list_orders``
+(``search`` matches order number) or ``get_order`` (by id).
 """
 
 from __future__ import annotations
@@ -272,21 +277,6 @@ def register_tools(mcp: FastMCP) -> None:
             due_date_range=due_date_range,
             history_table=history_table,
         )
-
-    @mcp.tool(
-        name="lookup_order",
-        description="Look up an order by order number + customer email.",
-    )
-    async def lookup_order(
-        context: Context,
-        number: Annotated[
-            str, Field(description="Order number, e.g. '1188' or '#1188'")
-        ],
-        email: Annotated[str, Field(description="Customer email address")],
-    ) -> OrderSummary:
-        services = get_services(context)
-        order = await services.client.orders.lookup(number=number, email=email)
-        return _to_summary(order)
 
     @mcp.tool(
         name="update_order_status",


### PR DESCRIPTION
## Summary

Removes the `lookup_order` MCP tool. `GET /orders/lookup` is StatusPro's customer-verification path (unauthenticated, requires `number` + `email`) — exposing it to a Bearer-token MCP caller was strictly worse than the existing `list_orders(search=…)` and `get_order(id=…)` paths.

`Orders.lookup()` on the Python client is retained (still part of the documented public API for non-MCP consumers).

## Why

Diagnosed during the wider tool-surface audit — see epic #31. Was originally part of #27 but was bumped out due to a merge conflict with #20's Prefab UI rewrite of `tools/orders.py`. This PR applies the change cleanly on top of current main.

## Test plan

- [x] `uv run poe check` — 202 tests pass, no new failures
- [x] No remaining `lookup_order` references in `statuspro_mcp_server/` or tests
- [ ] Verify against live MCP: tool no longer enumerated; `list_orders(search="WEB20481")` reaches the same destination

## Closes

Closes #35.

## Breaking change

The `lookup_order` MCP tool no longer exists. Migration: use `list_orders(search=order_number)` (fuzzy) or `get_order(id=…)` (exact) instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)