### PR TITLE
feat: get_order history truncation + new get_order_history tool (and fix latent empty-history bug)

### DIFF
--- a/statuspro_mcp_server/src/statuspro_mcp/resources/help.py
+++ b/statuspro_mcp_server/src/statuspro_mcp/resources/help.py
@@ -12,7 +12,8 @@ _HELP_MARKDOWN = """\
 | Tool | Endpoint | Purpose |
 | ---- | -------- | ------- |
 | `list_orders` | `GET /orders` | Paginated list with filters (search, status, tags, due-date range). Auto-paginates. `search` matches order number, name, or customer fields — use it to find an order from just an order number. |
-| `get_order` | `GET /orders/{id}` | Full detail for one order, including history. |
+| `get_order` | `GET /orders/{id}` | Full detail for one order, with the most recent `history_limit` history entries (default 50). When `history_truncated` is true, use `get_order_history` for older entries. |
+| `get_order_history` | `GET /orders/{id}` (client-side paged) | Page through the full history timeline of one order. Use when `get_order` indicated truncation. |
 | `get_viable_statuses` | `GET /orders/{id}/viable-statuses` | Valid status transitions for the order's current state. |
 | `update_order_status` | `POST /orders/{id}/status` | Change status. Two-step confirm. |
 | `add_order_comment` | `POST /orders/{id}/comment` | Add a history comment. Two-step confirm. 5/min. |

--- a/statuspro_mcp_server/src/statuspro_mcp/server.py
+++ b/statuspro_mcp_server/src/statuspro_mcp/server.py
@@ -223,6 +223,7 @@ The client automatically retries with exponential backoff on 429 responses.
 _READ_ONLY_TOOLS = [
     "list_orders",
     "get_order",
+    "get_order_history",
     "list_statuses",
     "get_viable_statuses",
 ]

--- a/statuspro_mcp_server/src/statuspro_mcp/tools/orders.py
+++ b/statuspro_mcp_server/src/statuspro_mcp/tools/orders.py
@@ -1,6 +1,6 @@
 """MCP tools for StatusPro orders.
 
-6 tools mapping to the ``/orders*`` endpoints. Mutations use a two-step confirm
+7 tools mapping to the ``/orders*`` endpoints. Mutations use a two-step confirm
 pattern: call with ``confirm=False`` to see a preview, then ``confirm=True`` to
 execute (the client host elicits explicit user approval via ``ctx.elicit``).
 
@@ -33,6 +33,7 @@ from statuspro_mcp.tools.schemas import (
     ConfirmationResult,
     HistoryEntry,
     OrderDetail,
+    OrderHistoryPage,
     OrderList,
     OrderSummary,
     StatusChangePreview,
@@ -93,14 +94,31 @@ def _history_entry(item: Any) -> HistoryEntry:
     )
 
 
-def _to_detail(order: Any) -> OrderDetail:
-    """Convert a domain Order into a full ``OrderDetail`` including history."""
+DEFAULT_HISTORY_LIMIT = 50
+
+
+def _to_detail(
+    order: Any, *, history_limit: int = DEFAULT_HISTORY_LIMIT
+) -> OrderDetail:
+    """Convert a domain Order into a full ``OrderDetail``.
+
+    History is truncated to the most recent ``history_limit`` entries
+    (server returns chronological order, so we slice from the tail).
+    Callers receive ``history_truncated`` + ``history_total_count`` to
+    detect truncation and page through older entries via
+    ``get_order_history``.
+    """
     summary = _to_summary(order)
     history_items = getattr(order, "history", None) or []
+    total = len(history_items)
+    truncated = total > history_limit
+    visible = history_items[-history_limit:] if truncated else history_items
     return OrderDetail(
         **summary.model_dump(),
         due_date_to=iso_or_none(getattr(order, "due_date_to", None)),
-        history=[_history_entry(h) for h in history_items],
+        history=[_history_entry(h) for h in visible],
+        history_truncated=truncated,
+        history_total_count=total,
     )
 
 
@@ -228,12 +246,25 @@ def register_tools(mcp: FastMCP) -> None:
 
     @mcp.tool(
         name="get_order",
-        description="Fetch full details for one order by id (with history).",
+        description=(
+            "Fetch full details for one order by id (with history). "
+            "History is capped at history_limit entries (default 50, most recent); "
+            "if history_truncated is true on the result, use get_order_history to "
+            "page through older entries."
+        ),
         meta=UI_META,
     )
     async def get_order(
         context: Context,
         order_id: Annotated[int, Field(description="StatusPro order id")],
+        history_limit: Annotated[
+            int,
+            Field(
+                description="Max history entries to include (most recent N).",
+                ge=1,
+                le=500,
+            ),
+        ] = DEFAULT_HISTORY_LIMIT,
     ) -> ToolResult:
         services = get_services(context)
         order, catalog = await asyncio.gather(
@@ -241,26 +272,34 @@ def register_tools(mcp: FastMCP) -> None:
             _status_color_catalog(services),
         )
 
-        detail = _to_detail(order)
+        detail = _to_detail(order, history_limit=history_limit)
         status_color = catalog.get(detail.status_code) if detail.status_code else None
 
         app = build_order_detail_ui(detail.model_dump(), status_color=status_color)
 
-        history_table = (
-            format_md_table(
-                headers=["When", "Event", "Status", "Comment"],
-                rows=[
-                    [
-                        h.created_at or "—",
-                        h.event or "—",
-                        h.status_name or "—",
-                        h.comment or "—",
-                    ]
-                    for h in detail.history
-                ],
-            )
-            or "_(no history)_"
+        history_rows = format_md_table(
+            headers=["When", "Event", "Status", "Comment"],
+            rows=[
+                [
+                    h.created_at or "—",
+                    h.event or "—",
+                    h.status_name or "—",
+                    h.comment or "—",
+                ]
+                for h in detail.history
+            ],
         )
+        if not history_rows:
+            history_table = "_(no history)_"
+        elif detail.history_truncated:
+            history_table = (
+                f"_Showing {len(detail.history)} most recent of "
+                f"{detail.history_total_count} entries — use "
+                f"`get_order_history(order_id={detail.id})` for older entries._\n\n"
+                + history_rows
+            )
+        else:
+            history_table = history_rows
         due_date_range = f" — {detail.due_date_to}" if detail.due_date_to else ""
 
         return make_tool_result(
@@ -276,6 +315,45 @@ def register_tools(mcp: FastMCP) -> None:
             due_date=detail.due_date or "—",
             due_date_range=due_date_range,
             history_table=history_table,
+        )
+
+    @mcp.tool(
+        name="get_order_history",
+        description=(
+            "Page through an order's full history timeline. Useful when "
+            "get_order returned history_truncated=true and you need older "
+            "entries. Page is 1-based; per_page defaults to 50, max 100."
+        ),
+    )
+    async def get_order_history(
+        context: Context,
+        order_id: Annotated[int, Field(description="StatusPro order id")],
+        page: Annotated[
+            int,
+            Field(description="1-based page number.", ge=1),
+        ] = 1,
+        per_page: Annotated[
+            int,
+            Field(description="Entries per page (max 100).", ge=1, le=100),
+        ] = 50,
+    ) -> OrderHistoryPage:
+        services = get_services(context)
+        # No server-side history pagination today — fetch the full order and
+        # slice client-side. Cheap relative to LLM context cost.
+        order = await services.client.orders.get(order_id)
+        all_items = getattr(order, "history", None) or []
+        total = len(all_items)
+        total_pages = max(1, (total + per_page - 1) // per_page)
+        start = (page - 1) * per_page
+        end = start + per_page
+        page_items = all_items[start:end]
+        return OrderHistoryPage(
+            order_id=order_id,
+            page=page,
+            per_page=per_page,
+            total=total,
+            total_pages=total_pages,
+            entries=[_history_entry(h) for h in page_items],
         )
 
     @mcp.tool(

--- a/statuspro_mcp_server/src/statuspro_mcp/tools/schemas.py
+++ b/statuspro_mcp_server/src/statuspro_mcp/tools/schemas.py
@@ -86,14 +86,38 @@ class HistoryEntry(BaseModel):
 
 
 class OrderDetail(OrderSummary):
-    """Full order record including the history timeline.
+    """Full order record including the (possibly truncated) history timeline.
 
     Returned by ``get_order`` — extends ``OrderSummary`` with the fields that
-    aren't useful in list views.
+    aren't useful in list views. The ``history`` array is truncated to the
+    most recent ``history_limit`` entries when the order has many; callers
+    should check ``history_truncated`` and use ``get_order_history`` to page
+    through older entries when set.
     """
 
     due_date_to: str | None = None
     history: list[HistoryEntry] = Field(default_factory=list)
+    history_truncated: bool = Field(
+        default=False,
+        description="True when older history entries were omitted; "
+        "use get_order_history to page through them.",
+    )
+    history_total_count: int = Field(
+        default=0,
+        description="Total number of history entries on the order; "
+        "len(history) <= history_total_count.",
+    )
+
+
+class OrderHistoryPage(BaseModel):
+    """One page of history entries returned by ``get_order_history``."""
+
+    order_id: int
+    page: int
+    per_page: int
+    total: int
+    total_pages: int
+    entries: list[HistoryEntry]
 
 
 class OrderList(BaseModel):
@@ -165,6 +189,7 @@ __all__ = [
     "ConfirmationSchema",
     "HistoryEntry",
     "OrderDetail",
+    "OrderHistoryPage",
     "OrderList",
     "OrderSummary",
     "StatusChangePreview",

--- a/statuspro_mcp_server/tests/tools/test_orders_history_truncation.py
+++ b/statuspro_mcp_server/tests/tools/test_orders_history_truncation.py
@@ -1,0 +1,141 @@
+"""Tests for history truncation in _to_detail and the get_order_history tool.
+
+Covers the contract from issue #40: get_order returns the most recent
+`history_limit` entries (default 50) with `history_truncated` and
+`history_total_count` flags so callers know to use get_order_history
+for older entries.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from statuspro_mcp.tools.orders import (
+    DEFAULT_HISTORY_LIMIT,
+    _history_entry,
+    _to_detail,
+)
+
+from statuspro_public_api_client.domain import HistoryEntry, Order, OrderStatus
+
+
+def _make_order(*, history_count: int) -> Order:
+    """Build a domain Order with `history_count` history entries.
+
+    Entries are ordered chronologically (oldest first) — server convention.
+    """
+    history = [
+        HistoryEntry(
+            event="status_change",
+            status=OrderStatus(code="st000002", name="In Production"),
+            comment=None,
+            comment_is_public=False,
+            created_at=datetime(2026, 1, 1, 10, 0, i % 60, tzinfo=UTC),
+        )
+        for i in range(history_count)
+    ]
+    return Order(
+        id=42,
+        name="#42",
+        order_number="42",
+        history=history,
+    )
+
+
+@pytest.mark.unit
+class TestToDetailTruncation:
+    """_to_detail respects history_limit and reports truncation accurately."""
+
+    def test_no_history_returns_empty_not_truncated(self):
+        order = Order(id=1, name="#1")
+        detail = _to_detail(order)
+        assert detail.history == []
+        assert detail.history_truncated is False
+        assert detail.history_total_count == 0
+
+    def test_history_below_limit_passes_through(self):
+        order = _make_order(history_count=10)
+        detail = _to_detail(order, history_limit=DEFAULT_HISTORY_LIMIT)
+        assert len(detail.history) == 10
+        assert detail.history_truncated is False
+        assert detail.history_total_count == 10
+
+    def test_history_at_limit_not_truncated(self):
+        """Exactly N entries with limit=N is not truncation."""
+        order = _make_order(history_count=DEFAULT_HISTORY_LIMIT)
+        detail = _to_detail(order)
+        assert len(detail.history) == DEFAULT_HISTORY_LIMIT
+        assert detail.history_truncated is False
+        assert detail.history_total_count == DEFAULT_HISTORY_LIMIT
+
+    def test_history_above_limit_truncated_to_most_recent(self):
+        """Server returns chronological (oldest first); we keep the tail."""
+        order = _make_order(history_count=DEFAULT_HISTORY_LIMIT + 7)
+        detail = _to_detail(order)
+        assert len(detail.history) == DEFAULT_HISTORY_LIMIT
+        assert detail.history_truncated is True
+        assert detail.history_total_count == DEFAULT_HISTORY_LIMIT + 7
+
+        # The kept entries are the LAST N (most recent), not the first N.
+        # First kept entry is index 7 (entries 0..6 were trimmed). created_at
+        # on the MCP-shaped HistoryEntry is the ISO string, so parse to check
+        # the second.
+        first_kept = detail.history[0].created_at
+        assert first_kept is not None
+        first_kept_dt = datetime.fromisoformat(first_kept)
+        assert first_kept_dt.second == 7 % 60
+
+    def test_custom_history_limit_smaller(self):
+        order = _make_order(history_count=20)
+        detail = _to_detail(order, history_limit=5)
+        assert len(detail.history) == 5
+        assert detail.history_truncated is True
+        assert detail.history_total_count == 20
+
+    def test_custom_history_limit_zero_is_not_supported(self):
+        """history_limit must be >= 1 — guarded at the MCP tool layer.
+        Internal _to_detail with limit=0 would slice to []; verify the slice
+        math doesn't blow up (defensive).
+        """
+        order = _make_order(history_count=5)
+        # The tool itself rejects limit < 1 via Field(ge=1), but the helper
+        # is permissive — verify it produces a sane result.
+        detail = _to_detail(order, history_limit=1)
+        assert len(detail.history) == 1
+        assert detail.history_truncated is True
+
+
+@pytest.mark.unit
+class TestHistoryEntryConversion:
+    """_history_entry converts a domain HistoryEntry into the MCP shape."""
+
+    def test_status_change_entry(self):
+        domain_entry = HistoryEntry(
+            event="status_change",
+            status=OrderStatus(code="st000002", name="In Production"),
+            comment=None,
+            comment_is_public=False,
+            created_at=datetime(2026, 3, 12, 10, 14, tzinfo=UTC),
+        )
+        mcp_entry = _history_entry(domain_entry)
+        assert mcp_entry.event == "status_change"
+        assert mcp_entry.status_code == "st000002"
+        assert mcp_entry.status_name == "In Production"
+        assert mcp_entry.comment is None
+        assert mcp_entry.created_at == "2026-03-12T10:14:00+00:00"
+
+    def test_comment_entry(self):
+        domain_entry = HistoryEntry(
+            event="comment_added",
+            status=None,
+            comment="Customer asked about ETA.",
+            comment_is_public=False,
+            created_at=datetime(2026, 3, 13, 9, 0, tzinfo=UTC),
+        )
+        mcp_entry = _history_entry(domain_entry)
+        assert mcp_entry.event == "comment_added"
+        assert mcp_entry.status_code is None
+        assert mcp_entry.status_name is None
+        assert mcp_entry.comment == "Customer asked about ETA."
+        assert mcp_entry.comment_is_public is False

--- a/statuspro_public_api_client/domain/__init__.py
+++ b/statuspro_public_api_client/domain/__init__.py
@@ -18,11 +18,12 @@ Example:
 
 from .base import StatusProBaseModel
 from .converters import to_unset, unwrap_unset
-from .order import Customer, Order, OrderStatus, PageMeta
+from .order import Customer, HistoryEntry, Order, OrderStatus, PageMeta
 from .status import Status
 
 __all__ = [
     "Customer",
+    "HistoryEntry",
     "Order",
     "OrderStatus",
     "PageMeta",

--- a/statuspro_public_api_client/domain/order.py
+++ b/statuspro_public_api_client/domain/order.py
@@ -46,6 +46,23 @@ class OrderStatus(_Frozen):
     auto_change_at: AwareDatetime | None = None
 
 
+class HistoryEntry(_Frozen):
+    """One entry in an order's history timeline.
+
+    Returned only by ``/orders/{id}`` (single-order detail), never on list
+    pages. Covers status transitions (``status`` is set, ``comment`` may be
+    set or empty) and free-form comments (``comment`` set, ``status`` usually
+    not). The ``mail_log`` audit field on the underlying API is intentionally
+    omitted — operational tooling rarely needs it and it's verbose.
+    """
+
+    event: str | None = None
+    status: OrderStatus | None = None
+    comment: str | None = None
+    comment_is_public: bool | None = None
+    created_at: AwareDatetime | None = None
+
+
 class Order(_Frozen):
     """An order as returned by ``/orders`` list pages or ``/orders/{id}``."""
 
@@ -59,6 +76,10 @@ class Order(_Frozen):
     history_count: int | None = Field(
         None,
         description="Number of history entries; only present on list responses",
+    )
+    history: list[HistoryEntry] | None = Field(
+        None,
+        description="Full history timeline; only present on single-order detail responses",
     )
 
 
@@ -84,4 +105,4 @@ class PageMeta(_Frozen):
     )
 
 
-__all__ = ["Customer", "Order", "OrderStatus", "PageMeta"]
+__all__ = ["Customer", "HistoryEntry", "Order", "OrderStatus", "PageMeta"]

--- a/tests/test_domain_order_history.py
+++ b/tests/test_domain_order_history.py
@@ -1,0 +1,113 @@
+"""Tests for HistoryEntry parsing on the domain Order pydantic model.
+
+The domain Order is validated from `OrderResponse.to_dict()`, which is the
+shape the server returns for `GET /orders/{id}`. The pydantic model uses
+`extra="ignore"`, so any field that isn't explicitly declared on the model
+is silently dropped. These tests pin down that `history` IS declared and
+populates correctly — without them, the MCP `get_order` tool's history
+field silently regresses to empty (the bug fixed in #40).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from statuspro_public_api_client.domain import HistoryEntry, Order
+
+
+@pytest.mark.unit
+class TestOrderHistoryParsing:
+    """Order.model_validate() correctly populates history entries."""
+
+    def test_order_with_no_history_field(self):
+        """A response with no `history` key parses to history=None."""
+        order = Order.model_validate(
+            {
+                "id": 123,
+                "name": "#1188",
+                "order_number": "1188",
+            }
+        )
+        assert order.history is None
+
+    def test_order_with_empty_history_array(self):
+        """A response with `history: []` parses to history=[] (distinct from None)."""
+        order = Order.model_validate(
+            {
+                "id": 123,
+                "name": "#1188",
+                "order_number": "1188",
+                "history": [],
+            }
+        )
+        assert order.history == []
+
+    def test_order_with_history_entries(self):
+        """All fields on each history entry round-trip from server-shaped dict."""
+        order = Order.model_validate(
+            {
+                "id": 123,
+                "name": "#1188",
+                "order_number": "1188",
+                "history": [
+                    {
+                        "event": "status_change",
+                        "status": {
+                            "is_set": True,
+                            "code": "st000002",
+                            "name": "In Production",
+                            "public": True,
+                        },
+                        "comment": None,
+                        "comment_is_public": False,
+                        "created_at": "2026-03-12T10:14:00+00:00",
+                    },
+                    {
+                        "event": "comment_added",
+                        "status": None,
+                        "comment": "Customer asked about ETA.",
+                        "comment_is_public": False,
+                        "created_at": "2026-03-13T09:00:00+00:00",
+                    },
+                ],
+            }
+        )
+        assert order.history is not None
+        assert len(order.history) == 2
+
+        first, second = order.history
+        assert isinstance(first, HistoryEntry)
+        assert first.event == "status_change"
+        assert first.status is not None
+        assert first.status.code == "st000002"
+        assert first.status.name == "In Production"
+        assert first.comment is None
+        assert first.created_at is not None
+        assert first.created_at.isoformat() == "2026-03-12T10:14:00+00:00"
+
+        assert second.event == "comment_added"
+        assert second.status is None
+        assert second.comment == "Customer asked about ETA."
+
+    def test_order_drops_mail_log_field(self):
+        """The audit `mail_log` field on server HistoryItem is intentionally
+        not exposed on the domain HistoryEntry. Should not cause a parse error
+        — `extra="ignore"` drops it silently.
+        """
+        order = Order.model_validate(
+            {
+                "id": 123,
+                "history": [
+                    {
+                        "event": "status_change",
+                        "status": None,
+                        "created_at": "2026-03-12T10:14:00+00:00",
+                        "mail_log": {"sent_at": "2026-03-12T10:15:00+00:00"},
+                    }
+                ],
+            }
+        )
+        assert order.history is not None
+        assert len(order.history) == 1
+        # mail_log isn't on the model — verifying via attribute access raises
+        assert not hasattr(order.history[0], "mail_log")


### PR DESCRIPTION
## Summary

Implements #40, plus fixes a pre-existing bug found while starting.

### Two commits

**Commit 1 — `fix(client): expose history entries on domain Order model`**

While planning #40 I discovered the domain `Order` Pydantic model only declared `history_count`, not the `history` array itself, and the `_Frozen` base sets `extra="ignore"`. Any history returned by the server's `OrderResponse` was silently dropped during pydantic validation in `Orders.get()`. Result: the MCP `get_order` tool's `history` field has been **always empty in practice today**, regardless of the underlying order data.

Adds `HistoryEntry` Pydantic model and `history: list[HistoryEntry] | None` field on `Order`. The verbose `mail_log` audit field on the server `HistoryItem` is intentionally not exposed — operational tooling rarely needs it.

**Commit 2 — `feat(mcp): truncate get_order history and add get_order_history tool`**

`get_order` now returns the most recent `history_limit` entries (default 50, max 500), with:
- `history_truncated: bool` — true when older entries were omitted
- `history_total_count: int` — total entries on the order

Markdown rendering shows a hint when truncation occurs, pointing at the new `get_order_history(order_id, page=, per_page=)` tool. The new tool paginates client-side over the embedded history array (no server-side history pagination today). Added to `_READ_ONLY_TOOLS` for response caching.

## Test plan

- [x] `uv run poe check` — 214 tests pass (+12 new: 4 domain `HistoryEntry` parsing + 6 truncation + 2 entry-conversion)
- [x] No `mail_log` field exposed (intentional — domain layer is curated)
- [x] Truncation keeps the tail (most recent), not the head
- [x] `history_truncated` flag accurately reflects whether truncation occurred
- [x] Tool docstrings + help resource updated to reflect new behavior

## Closes

Closes #40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)