### PR TITLE
feat(mcp): update_order_status preview self-validates against viable transitions

### DIFF
--- a/statuspro_mcp_server/src/statuspro_mcp/resources/help.py
+++ b/statuspro_mcp_server/src/statuspro_mcp/resources/help.py
@@ -15,7 +15,7 @@ _HELP_MARKDOWN = """\
 | `get_order` | `GET /orders/{id}` | Full detail for one order, with the most recent `history_limit` history entries (default 50). When `history_truncated` is true, use `get_order_history` for older entries. |
 | `get_order_history` | `GET /orders/{id}` (client-side paged) | Page through the full history timeline of one order. Use when `get_order` indicated truncation. |
 | `get_viable_statuses` | `GET /orders/{id}/viable-statuses` | Valid status transitions for the order's current state. |
-| `update_order_status` | `POST /orders/{id}/status` | Change status. Two-step confirm. |
+| `update_order_status` | `POST /orders/{id}/status` | Change status. Two-step confirm. Preview self-validates against viable transitions — invalid `status_code` is caught at preview time without the API round-trip. |
 | `add_order_comment` | `POST /orders/{id}/comment` | Add a history comment. Two-step confirm. 5/min. |
 | `update_order_due_date` | `POST /orders/{id}/due-date` | Change due date / date range. Two-step confirm. |
 | `bulk_update_order_status` | `POST /orders/bulk-status` | Update up to 50 orders in one request. Two-step confirm. 5/min. |

--- a/statuspro_mcp_server/src/statuspro_mcp/templates/status_change_preview.md
+++ b/statuspro_mcp_server/src/statuspro_mcp/templates/status_change_preview.md
@@ -2,6 +2,8 @@
 
 **{current_status_name}** ({current_status_code}) → **{new_status_name}** ({new_status_code})
 
+{validity_block}
+
 {comment_block}
 
 Emails: {recipients}

--- a/statuspro_mcp_server/src/statuspro_mcp/tools/orders.py
+++ b/statuspro_mcp_server/src/statuspro_mcp/tools/orders.py
@@ -389,13 +389,18 @@ def register_tools(mcp: FastMCP) -> None:
         services = get_services(context)
 
         if not confirm:
-            # Preview branch: fetch the order + catalog so the UI can show
-            # the current status side-by-side with the proposed new one.
+            # Preview branch: fetch order + status catalog + viable transitions
+            # in parallel so the UI can show current vs. proposed AND so we
+            # can pre-validate the transition before the user confirms (saves
+            # the agent from getting a 422 surprise on the confirm step).
+            order, statuses_list, viable = await asyncio.gather(
+                services.client.orders.get(order_id),
+                services.client.statuses.list(),
+                services.client.statuses.viable_for(order_id),
+            )
+
             # Single catalog fetch services both the color map and the
-            # new-status-name lookup (``list_statuses`` is cached, but pulling
-            # the local list avoids round-tripping the cache twice).
-            order = await services.client.orders.get(order_id)
-            statuses_list = await services.client.statuses.list()
+            # new-status-name lookup (``list_statuses`` is cached).
             catalog: dict[str, str | None] = {}
             new_name: str | None = None
             for s in statuses_list:
@@ -405,6 +410,13 @@ def register_tools(mcp: FastMCP) -> None:
                 catalog[code] = getattr(s, "color", None)
                 if code == status_code:
                     new_name = getattr(s, "name", None)
+
+            viable_codes: list[str] = []
+            for s in viable:
+                code = getattr(s, "code", None)
+                if isinstance(code, str) and code:
+                    viable_codes.append(code)
+            valid_transition = status_code in viable_codes
 
             current = getattr(order, "status", None)
             current_code = getattr(current, "code", None) if current else None
@@ -420,6 +432,8 @@ def register_tools(mcp: FastMCP) -> None:
                 public=public,
                 email_customer=email_customer,
                 email_additional=email_additional,
+                valid=valid_transition,
+                viable_status_codes=viable_codes,
             )
             app = build_status_change_preview_ui(
                 preview.model_dump(),
@@ -433,6 +447,13 @@ def register_tools(mcp: FastMCP) -> None:
                 if comment
                 else "_No comment._"
             )
+            validity_block = (
+                f"⚠️ **Not a valid transition.** Viable status codes from "
+                f"`{current_code or '—'}`: "
+                + (", ".join(f"`{c}`" for c in viable_codes) or "_(none)_")
+                if not valid_transition
+                else ""
+            )
 
             return make_tool_result(
                 preview,
@@ -445,6 +466,7 @@ def register_tools(mcp: FastMCP) -> None:
                 new_status_name=new_name or "—",
                 comment_block=comment_block,
                 recipients=recipients_text,
+                validity_block=validity_block,
             )
 
         # Confirm branch: elicit approval, then execute. Renders the

--- a/statuspro_mcp_server/src/statuspro_mcp/tools/prefab_ui.py
+++ b/statuspro_mcp_server/src/statuspro_mcp/tools/prefab_ui.py
@@ -280,10 +280,17 @@ def build_status_change_preview_ui(
 
     Shows current → new side by side, the optional comment (with visibility
     badge), and a Confirm button that sends the ``confirm=true`` follow-up.
+
+    When ``preview["valid"]`` is ``False`` (the requested ``new_status_code``
+    is not a viable transition from the current state), the Confirm button is
+    replaced with a destructive warning surfacing the list of viable codes
+    so the agent can self-correct.
     """
     order_id = preview.get("order_id")
     comment = preview.get("comment")
     public = bool(preview.get("public"))
+    valid = bool(preview.get("valid", True))
+    viable_codes = preview.get("viable_status_codes") or []
     # Re-hydrate as the schema so its ``recipients_text`` is the single source
     # of truth for both the UI and the markdown fallback rendered by orders.py.
     recipients_text = StatusChangePreview.model_validate(preview).recipients_text()
@@ -291,7 +298,10 @@ def build_status_change_preview_ui(
     with PrefabApp(state={"preview": preview}, css_class="p-4") as app, Card():
         with CardHeader(), Row(gap=2):
             CardTitle(content=f"Preview: order {order_id} status change")
-            Badge(label="PREVIEW", variant="secondary")
+            Badge(
+                label="INVALID TRANSITION" if not valid else "PREVIEW",
+                variant="destructive" if not valid else "secondary",
+            )
 
         with CardContent(), Column(gap=3):
             with Row(gap=3):
@@ -305,6 +315,21 @@ def build_status_change_preview_ui(
                     preview.get("new_status_code"),
                     preview.get("new_status_name"),
                     new_color,
+                )
+
+            if not valid:
+                Separator()
+                Text(
+                    content=(
+                        f"⚠ Not a viable transition from "
+                        f"`{preview.get('current_status_code') or '—'}`. "
+                        f"Viable codes: "
+                        + (
+                            ", ".join(f"`{c}`" for c in viable_codes)
+                            if viable_codes
+                            else "_(none)_"
+                        )
+                    ),
                 )
 
             if comment:
@@ -321,14 +346,24 @@ def build_status_change_preview_ui(
             Metric(label="Emails to", value=recipients_text)
 
         with CardFooter(), Row(gap=2):
-            Button(
-                label="Confirm change",
-                variant="default",
-                on_click=SendMessage(
-                    f"Update order {order_id} to status "
-                    f"{preview.get('new_status_code')} with confirm=true"
-                ),
-            )
+            if valid:
+                Button(
+                    label="Confirm change",
+                    variant="default",
+                    on_click=SendMessage(
+                        f"Update order {order_id} to status "
+                        f"{preview.get('new_status_code')} with confirm=true"
+                    ),
+                )
+            else:
+                Button(
+                    label="See viable transitions",
+                    variant="default",
+                    on_click=CallTool(
+                        "get_viable_statuses",
+                        arguments={"order_id": order_id},
+                    ),
+                )
             Button(
                 label="Cancel",
                 variant="outline",

--- a/statuspro_mcp_server/src/statuspro_mcp/tools/schemas.py
+++ b/statuspro_mcp_server/src/statuspro_mcp/tools/schemas.py
@@ -147,7 +147,14 @@ class ViableStatusesResponse(BaseModel):
 class StatusChangePreview(BaseModel):
     """Preview payload returned when ``update_order_status`` is called with
     ``confirm=False``. Describes the change that *would* happen, without
-    executing it."""
+    executing it.
+
+    The preview branch self-validates the requested transition against
+    ``GET /orders/{id}/viable-statuses``. When ``valid`` is ``False``, the
+    Confirm button on the Prefab UI is replaced with a warning surfacing
+    the list of ``viable_status_codes`` so the agent can self-correct
+    without a separate ``get_viable_statuses`` round-trip.
+    """
 
     action: Literal["update_order_status"] = "update_order_status"
     confirmed: Literal[False] = False
@@ -160,6 +167,17 @@ class StatusChangePreview(BaseModel):
     public: bool
     email_customer: bool
     email_additional: bool
+    valid: bool = Field(
+        default=True,
+        description=(
+            "True when new_status_code is a viable transition from the "
+            "current state. False blocks confirmation."
+        ),
+    )
+    viable_status_codes: list[str] = Field(
+        default_factory=list,
+        description="Status codes that ARE viable transitions, for self-correction.",
+    )
 
     def recipients_text(self) -> str:
         """Human-readable list of who will receive notification emails."""

--- a/statuspro_mcp_server/tests/tools/test_prefab_ui.py
+++ b/statuspro_mcp_server/tests/tools/test_prefab_ui.py
@@ -121,6 +121,8 @@ def test_build_status_change_preview_ui_renders_with_confirm_action():
             "public": True,
             "email_customer": True,
             "email_additional": False,
+            "valid": True,
+            "viable_status_codes": ["st000003", "st000004"],
         },
         current_color="pink",
         new_color="green",
@@ -131,3 +133,35 @@ def test_build_status_change_preview_ui_renders_with_confirm_action():
     serialized = json.dumps(_envelope(app))
     assert "confirm=true" in serialized
     assert "st000003" in serialized
+
+
+def test_build_status_change_preview_ui_invalid_transition_hides_confirm():
+    """When valid=False, the Confirm button is replaced with a 'See viable
+    transitions' button that calls get_viable_statuses, and the destructive
+    INVALID TRANSITION badge surfaces. Without these, an agent that tried an
+    invalid status_code could still confirm into a guaranteed 422.
+    """
+    app = build_status_change_preview_ui(
+        {
+            "order_id": 1,
+            "current_status_code": "st000002",
+            "current_status_name": "In Production",
+            "new_status_code": "st000099",
+            "new_status_name": None,
+            "comment": None,
+            "public": False,
+            "email_customer": True,
+            "email_additional": True,
+            "valid": False,
+            "viable_status_codes": ["st000003", "st000004"],
+        },
+    )
+    serialized = json.dumps(_envelope(app))
+    # No Confirm button → no "confirm=true" SendMessage payload.
+    assert "confirm=true" not in serialized
+    # The remediation path: the get_viable_statuses CallTool action must be
+    # wired to the replacement button.
+    assert "get_viable_statuses" in serialized
+    # Viable codes surface in the warning text so the agent can self-correct.
+    assert "st000003" in serialized
+    assert "st000004" in serialized


### PR DESCRIPTION
## Summary

Closes #38.

The preview branch of `update_order_status` (called with `confirm=False`) now fetches `viable_for(order_id)` in parallel with the order detail and status catalog, and sets two new fields on `StatusChangePreview`:

- `valid: bool` — true when `new_status_code` is a viable transition from the current state
- `viable_status_codes: list[str]` — the codes that ARE viable, for self-correction

When `valid=False`:
- Prefab UI replaces the **Confirm** button with a **See viable transitions** button (wired to `get_viable_statuses` via `CallTool`)
- An "INVALID TRANSITION" destructive badge replaces the "PREVIEW" badge
- The viable codes surface in a warning text block
- Markdown fallback gets a `validity_block` warning with the same content

## Why

Removes a real footgun. Today, an agent calling `update_order_status(order_id, "st00wrong", confirm=False)` gets a clean preview that says "Confirm to apply" — but on confirm, the API returns 422 and the user has wasted an elicitation interaction. The preview branch now catches the bad transition without any API round-trip on the *write* path; we just fetch viable-statuses (which is in `_READ_ONLY_TOOLS` and cached for 30s) so the preview→confirm flow doesn't re-fetch.

## Test plan

- [x] `uv run poe check` — 215 tests pass (+1 new: `test_build_status_change_preview_ui_invalid_transition_hides_confirm`)
- [x] Existing valid-transition test still passes (with new schema fields populated)
- [x] Help resource updated to document self-validation behavior

## Out of scope

The confirm branch (`confirm=True`) does NOT add an extra `viable_for` call. Rationale: in normal preview→confirm flow, the preview already validated, and the confirm runs immediately after; in direct-confirm (skipping preview), the agent is signaling "I know what I'm doing." Adding a guard there has marginal value vs. the rate-limit cost. Easy to revisit if it becomes a real footgun.

🤖 Generated with [Claude Code](https://claude.com/claude-code)