### PR TITLE
feat(mcp): Prefab UI parity for add_order_comment, update_order_due_date, bulk_update_order_status

### DIFF
--- a/statuspro_mcp_server/src/statuspro_mcp/templates/bulk_status_change_preview.md
+++ b/statuspro_mcp_server/src/statuspro_mcp/templates/bulk_status_change_preview.md
@@ -1,0 +1,11 @@
+# Preview: bulk status change ({order_count} orders)
+
+**Target status:** {target_status_name} ({target_status_code})
+
+**Order IDs:** {ids_preview}
+
+{comment_block}
+
+Emails: {recipients}
+
+Rerun with `confirm=true` to bulk-update all {order_count} orders.

--- a/statuspro_mcp_server/src/statuspro_mcp/templates/bulk_status_change_result.md
+++ b/statuspro_mcp_server/src/statuspro_mcp/templates/bulk_status_change_result.md
@@ -1,0 +1,5 @@
+# Bulk status change ({order_count} orders)
+
+- **Target status:** {target_status_code}
+- **Result:** {outcome}
+- **HTTP:** {http_status}{note_line}{message_line}

--- a/statuspro_mcp_server/src/statuspro_mcp/templates/comment_preview.md
+++ b/statuspro_mcp_server/src/statuspro_mcp/templates/comment_preview.md
@@ -1,0 +1,7 @@
+# Preview: comment on order {order_id}
+
+**Order:** {order_label}
+
+**Comment** ({visibility}): {comment}
+
+Rerun with `confirm=true` to add the comment.

--- a/statuspro_mcp_server/src/statuspro_mcp/templates/comment_result.md
+++ b/statuspro_mcp_server/src/statuspro_mcp/templates/comment_result.md
@@ -1,0 +1,4 @@
+# Comment on order {order_id}
+
+- **Result:** {outcome}
+- **HTTP:** {http_status}{message_line}

--- a/statuspro_mcp_server/src/statuspro_mcp/templates/due_date_change_preview.md
+++ b/statuspro_mcp_server/src/statuspro_mcp/templates/due_date_change_preview.md
@@ -1,0 +1,8 @@
+# Preview: due date for order {order_id}
+
+**Order:** {order_label}
+
+**Current:** {current_due_date}{current_range}
+**Proposed:** {new_due_date}{new_range}
+
+Rerun with `confirm=true` to apply the due date change.

--- a/statuspro_mcp_server/src/statuspro_mcp/templates/due_date_change_result.md
+++ b/statuspro_mcp_server/src/statuspro_mcp/templates/due_date_change_result.md
@@ -1,0 +1,5 @@
+# Due date change for order {order_id}
+
+- **New due date:** {new_due_date}{new_range}
+- **Result:** {outcome}
+- **HTTP:** {http_status}{message_line}

--- a/statuspro_mcp_server/src/statuspro_mcp/tools/orders.py
+++ b/statuspro_mcp_server/src/statuspro_mcp/tools/orders.py
@@ -4,9 +4,11 @@
 pattern: call with ``confirm=False`` to see a preview, then ``confirm=True`` to
 execute (the client host elicits explicit user approval via ``ctx.elicit``).
 
-Three tools — ``list_orders``, ``get_order``, ``update_order_status`` — return
-a Prefab UI for MCP-Apps clients (Claude Desktop) via ``make_tool_result`` and
-``meta=UI_META``. Others return plain Pydantic/dict responses.
+All read-and-mutation tools (``list_orders``, ``get_order``,
+``update_order_status``, ``add_order_comment``, ``update_order_due_date``,
+``bulk_update_order_status``) return a Prefab UI for MCP-Apps clients (Claude
+Desktop) via ``make_tool_result`` and ``meta=UI_META``. ``get_order_history``
+returns a plain Pydantic page (no UI surface needed for raw timeline data).
 
 The ``GET /orders/lookup`` endpoint is intentionally not exposed: it is the
 public, customer-verification path (requires ``number`` + ``email``) and adds
@@ -26,12 +28,21 @@ from pydantic import Field
 
 from statuspro_mcp.services import get_services
 from statuspro_mcp.tools.prefab_ui import (
+    build_bulk_status_change_preview_ui,
+    build_comment_preview_ui,
+    build_due_date_change_preview_ui,
     build_order_detail_ui,
     build_orders_table_ui,
     build_status_change_preview_ui,
 )
 from statuspro_mcp.tools.schemas import (
+    BulkStatusChangePreview,
+    BulkStatusChangeResult,
+    CommentPreview,
+    CommentResult,
     ConfirmationResult,
+    DueDateChangePreview,
+    DueDateChangeResult,
     HistoryEntry,
     OrderDetail,
     OrderHistoryPage,
@@ -558,6 +569,7 @@ def register_tools(mcp: FastMCP) -> None:
     @mcp.tool(
         name="add_order_comment",
         description="Add a history comment to an order (5/min rate limit). Two-step confirm.",
+        meta=UI_META,
     )
     async def add_order_comment(
         context: Context,
@@ -565,37 +577,78 @@ def register_tools(mcp: FastMCP) -> None:
         comment: Annotated[str, Field(description="Comment body")],
         public: Annotated[bool, Field(description="Visible to the customer")] = False,
         confirm: bool = False,
-    ) -> dict[str, Any]:
+    ) -> ToolResult:
         services = get_services(context)
 
-        preview = {
-            "action": "add_order_comment",
-            "order_id": order_id,
-            "comment": comment,
-            "public": public,
-        }
         if not confirm:
-            return {"preview": preview, "confirmed": False}
+            order = await services.client.orders.get(order_id)
+            order_summary = _to_summary(order)
+            preview_model = CommentPreview(
+                order_id=order_id,
+                order_summary=order_summary,
+                comment=comment,
+                public=public,
+            )
+            app = build_comment_preview_ui(preview_model.model_dump())
+            order_label = (
+                order_summary.name or order_summary.order_number or f"#{order_id}"
+            )
+            order_label = (
+                f"{order_label} ({order_summary.status_name})"
+                if order_summary.status_name
+                else order_label
+            )
+            return make_tool_result(
+                preview_model,
+                template_name="comment_preview",
+                ui=app,
+                order_id=order_id,
+                order_label=order_label,
+                comment=comment,
+                visibility="public" if public else "private",
+            )
 
-        result = await require_confirmation(
+        confirmation = await require_confirmation(
             context, f"Add comment to order {order_id}?"
         )
-        if result is not ConfirmationResult.CONFIRMED:
-            return {"preview": preview, "confirmed": False, "result": result.value}
+        if confirmation is not ConfirmationResult.CONFIRMED:
+            declined = CommentResult(
+                order_id=order_id,
+                success=False,
+                http_status=0,
+                message=f"User {confirmation.value}",
+            )
+            return make_tool_result(
+                declined,
+                template_name="comment_result",
+                order_id=order_id,
+                outcome=confirmation.value,
+                http_status=0,
+                message_line=f"\n- **Message:** User {confirmation.value}",
+            )
 
         body = AddOrderCommentRequest(comment=comment, public=public)
         response = await add_order_comment_api.asyncio_detailed(
             client=services.client, order=order_id, body=body
         )
-        return {
-            "confirmed": True,
-            "success": is_success(response),
-            "status_code": response.status_code,
-        }
+        outcome = CommentResult(
+            order_id=order_id,
+            success=is_success(response),
+            http_status=response.status_code,
+        )
+        return make_tool_result(
+            outcome,
+            template_name="comment_result",
+            order_id=order_id,
+            outcome="applied" if outcome.success else "failed",
+            http_status=response.status_code,
+            message_line="",
+        )
 
     @mcp.tool(
         name="update_order_due_date",
         description="Update an order's due date. Two-step confirm.",
+        meta=UI_META,
     )
     async def update_order_due_date(
         context: Context,
@@ -605,23 +658,70 @@ def register_tools(mcp: FastMCP) -> None:
             str | None, Field(description="Optional end of the range")
         ] = None,
         confirm: bool = False,
-    ) -> dict[str, Any]:
+    ) -> ToolResult:
         services = get_services(context)
 
-        preview = {
-            "action": "update_order_due_date",
-            "order_id": order_id,
-            "due_date": due_date,
-            "due_date_to": due_date_to,
-        }
         if not confirm:
-            return {"preview": preview, "confirmed": False}
+            order = await services.client.orders.get(order_id)
+            order_summary = _to_summary(order)
+            preview_model = DueDateChangePreview(
+                order_id=order_id,
+                order_summary=order_summary,
+                current_due_date=iso_or_none(getattr(order, "due_date", None)),
+                current_due_date_to=iso_or_none(getattr(order, "due_date_to", None)),
+                new_due_date=due_date,
+                new_due_date_to=due_date_to,
+            )
+            app = build_due_date_change_preview_ui(preview_model.model_dump())
+            order_label = (
+                order_summary.name or order_summary.order_number or f"#{order_id}"
+            )
+            order_label = (
+                f"{order_label} ({order_summary.status_name})"
+                if order_summary.status_name
+                else order_label
+            )
+            current_range = (
+                f" → {preview_model.current_due_date_to}"
+                if preview_model.current_due_date_to
+                else ""
+            )
+            new_range = f" → {due_date_to}" if due_date_to else ""
+            return make_tool_result(
+                preview_model,
+                template_name="due_date_change_preview",
+                ui=app,
+                order_id=order_id,
+                order_label=order_label,
+                current_due_date=preview_model.current_due_date or "—",
+                current_range=current_range,
+                new_due_date=due_date,
+                new_range=new_range,
+            )
 
-        result = await require_confirmation(
+        confirmation = await require_confirmation(
             context, f"Set due_date={due_date} for order {order_id}?"
         )
-        if result is not ConfirmationResult.CONFIRMED:
-            return {"preview": preview, "confirmed": False, "result": result.value}
+        if confirmation is not ConfirmationResult.CONFIRMED:
+            declined = DueDateChangeResult(
+                order_id=order_id,
+                new_due_date=due_date,
+                new_due_date_to=due_date_to,
+                success=False,
+                http_status=0,
+                message=f"User {confirmation.value}",
+            )
+            new_range = f" → {due_date_to}" if due_date_to else ""
+            return make_tool_result(
+                declined,
+                template_name="due_date_change_result",
+                order_id=order_id,
+                new_due_date=due_date,
+                new_range=new_range,
+                outcome=confirmation.value,
+                http_status=0,
+                message_line=f"\n- **Message:** User {confirmation.value}",
+            )
 
         body_kwargs: dict[str, Any] = {"due_date": due_date}
         if due_date_to is not None:
@@ -630,11 +730,24 @@ def register_tools(mcp: FastMCP) -> None:
         response = await set_order_due_date.asyncio_detailed(
             client=services.client, order=order_id, body=body
         )
-        return {
-            "confirmed": True,
-            "success": is_success(response),
-            "status_code": response.status_code,
-        }
+        outcome = DueDateChangeResult(
+            order_id=order_id,
+            new_due_date=due_date,
+            new_due_date_to=due_date_to,
+            success=is_success(response),
+            http_status=response.status_code,
+        )
+        new_range = f" → {due_date_to}" if due_date_to else ""
+        return make_tool_result(
+            outcome,
+            template_name="due_date_change_result",
+            order_id=order_id,
+            new_due_date=due_date,
+            new_range=new_range,
+            outcome="applied" if outcome.success else "failed",
+            http_status=response.status_code,
+            message_line="",
+        )
 
     @mcp.tool(
         name="bulk_update_order_status",
@@ -642,6 +755,7 @@ def register_tools(mcp: FastMCP) -> None:
             "Update status for up to 50 orders in one call (5/min rate limit). "
             "Returns 202 Accepted; updates are queued asynchronously."
         ),
+        meta=UI_META,
     )
     async def bulk_update_order_status(
         context: Context,
@@ -655,28 +769,74 @@ def register_tools(mcp: FastMCP) -> None:
         email_customer: bool = True,
         email_additional: bool = True,
         confirm: bool = False,
-    ) -> dict[str, Any]:
+    ) -> ToolResult:
         services = get_services(context)
 
-        preview = {
-            "action": "bulk_update_order_status",
-            "order_ids": order_ids,
-            "order_count": len(order_ids),
-            "status_code": status_code,
-            "comment": comment,
-            "public": public,
-            "email_customer": email_customer,
-            "email_additional": email_additional,
-        }
         if not confirm:
-            return {"preview": preview, "confirmed": False}
+            # Resolve target status name from the catalog so the preview can
+            # show "In Production" alongside the opaque code. statuses.list
+            # is cached at the middleware layer.
+            statuses_list = await services.client.statuses.list()
+            target_name: str | None = None
+            for s in statuses_list:
+                if getattr(s, "code", None) == status_code:
+                    target_name = getattr(s, "name", None)
+                    break
 
-        result = await require_confirmation(
+            preview_model = BulkStatusChangePreview(
+                order_ids=order_ids,
+                order_count=len(order_ids),
+                target_status_code=status_code,
+                target_status_name=target_name,
+                comment=comment,
+                public=public,
+                email_customer=email_customer,
+                email_additional=email_additional,
+            )
+            app = build_bulk_status_change_preview_ui(preview_model.model_dump())
+
+            ids_preview = ", ".join(str(i) for i in order_ids[:10])
+            if len(order_ids) > 10:
+                ids_preview += f", … (+{len(order_ids) - 10} more)"
+            comment_block = (
+                f"**Comment** ({'public' if public else 'private'}): {comment}"
+                if comment
+                else "_No comment._"
+            )
+            return make_tool_result(
+                preview_model,
+                template_name="bulk_status_change_preview",
+                ui=app,
+                order_count=len(order_ids),
+                target_status_code=status_code,
+                target_status_name=target_name or "—",
+                ids_preview=ids_preview,
+                comment_block=comment_block,
+                recipients=preview_model.recipients_text(),
+            )
+
+        confirmation = await require_confirmation(
             context,
             f"Bulk-update {len(order_ids)} orders to status {status_code}?",
         )
-        if result is not ConfirmationResult.CONFIRMED:
-            return {"preview": preview, "confirmed": False, "result": result.value}
+        if confirmation is not ConfirmationResult.CONFIRMED:
+            declined = BulkStatusChangeResult(
+                order_count=len(order_ids),
+                target_status_code=status_code,
+                success=False,
+                http_status=0,
+                message=f"User {confirmation.value}",
+            )
+            return make_tool_result(
+                declined,
+                template_name="bulk_status_change_result",
+                order_count=len(order_ids),
+                target_status_code=status_code,
+                outcome=confirmation.value,
+                http_status=0,
+                note_line="",
+                message_line=f"\n- **Message:** User {confirmation.value}",
+            )
 
         body = BulkStatusUpdateRequest(
             order_ids=order_ids,
@@ -689,9 +849,20 @@ def register_tools(mcp: FastMCP) -> None:
         response = await bulk_update_status.asyncio_detailed(
             client=services.client, body=body
         )
-        return {
-            "confirmed": True,
-            "success": is_success(response),
-            "status_code": response.status_code,
-            "note": "Bulk updates are queued and processed asynchronously.",
-        }
+        outcome = BulkStatusChangeResult(
+            order_count=len(order_ids),
+            target_status_code=status_code,
+            success=is_success(response),
+            http_status=response.status_code,
+            note="Bulk updates are queued and processed asynchronously.",
+        )
+        return make_tool_result(
+            outcome,
+            template_name="bulk_status_change_result",
+            order_count=len(order_ids),
+            target_status_code=status_code,
+            outcome="queued" if outcome.success else "failed",
+            http_status=response.status_code,
+            note_line="\n- **Note:** Bulk updates are queued and processed asynchronously.",
+            message_line="",
+        )

--- a/statuspro_mcp_server/src/statuspro_mcp/tools/orders.py
+++ b/statuspro_mcp_server/src/statuspro_mcp/tools/orders.py
@@ -524,6 +524,7 @@ def register_tools(mcp: FastMCP) -> None:
         )
         if result is not ConfirmationResult.CONFIRMED:
             declined = StatusChangeResult(
+                confirmed=False,
                 order_id=order_id,
                 new_status_code=status_code,
                 success=False,
@@ -613,6 +614,7 @@ def register_tools(mcp: FastMCP) -> None:
         )
         if confirmation is not ConfirmationResult.CONFIRMED:
             declined = CommentResult(
+                confirmed=False,
                 order_id=order_id,
                 success=False,
                 http_status=0,
@@ -704,6 +706,7 @@ def register_tools(mcp: FastMCP) -> None:
         )
         if confirmation is not ConfirmationResult.CONFIRMED:
             declined = DueDateChangeResult(
+                confirmed=False,
                 order_id=order_id,
                 new_due_date=due_date,
                 new_due_date_to=due_date_to,
@@ -821,6 +824,7 @@ def register_tools(mcp: FastMCP) -> None:
         )
         if confirmation is not ConfirmationResult.CONFIRMED:
             declined = BulkStatusChangeResult(
+                confirmed=False,
                 order_count=len(order_ids),
                 target_status_code=status_code,
                 success=False,

--- a/statuspro_mcp_server/src/statuspro_mcp/tools/prefab_ui.py
+++ b/statuspro_mcp_server/src/statuspro_mcp/tools/prefab_ui.py
@@ -372,7 +372,179 @@ def build_status_change_preview_ui(
     return app
 
 
+def _summary_chip(summary: dict[str, Any]) -> None:
+    """Render a compact "order #N (status)" chip for mutation previews."""
+    label = summary.get("name") or f"order #{summary.get('order_number') or '?'}"
+    status_name = summary.get("status_name") or "—"
+    Badge(label=f"{label} · {status_name}", variant="secondary")
+
+
+def build_comment_preview_ui(preview: dict[str, Any]) -> PrefabApp:
+    """Preview Card for ``add_order_comment``.
+
+    Shows which order the comment lands on (id + current status), the comment
+    body, and a public/private visibility badge — then the standard
+    Confirm/Cancel pair. Mirrors ``build_status_change_preview_ui`` so all
+    mutation previews share UX shape.
+    """
+    order_id = preview.get("order_id")
+    summary = preview.get("order_summary") or {}
+    comment = preview.get("comment") or ""
+    public = bool(preview.get("public"))
+
+    with PrefabApp(state={"preview": preview}, css_class="p-4") as app, Card():
+        with CardHeader(), Row(gap=2):
+            CardTitle(content=f"Preview: comment on order {order_id}")
+            Badge(label="PREVIEW", variant="secondary")
+
+        with CardContent(), Column(gap=3):
+            with Row(gap=2):
+                _summary_chip(summary)
+            Separator()
+            with Row(gap=2):
+                Muted(content="Comment:")
+                Text(content=comment)
+                Badge(
+                    label="public" if public else "private",
+                    variant="info" if public else "outline",
+                )
+
+        with CardFooter(), Row(gap=2):
+            Button(
+                label="Confirm comment",
+                variant="default",
+                on_click=SendMessage(
+                    f"Add comment to order {order_id} with confirm=true"
+                ),
+            )
+            Button(
+                label="Cancel",
+                variant="outline",
+                on_click=SendMessage("Cancel the comment"),
+            )
+    return app
+
+
+def build_due_date_change_preview_ui(preview: dict[str, Any]) -> PrefabApp:
+    """Preview Card for ``update_order_due_date``.
+
+    Shows current vs. proposed due_date (and due_date_to if set) side-by-side
+    so the agent can see the delta before confirming.
+    """
+    order_id = preview.get("order_id")
+    summary = preview.get("order_summary") or {}
+    current = preview.get("current_due_date") or "—"
+    current_to = preview.get("current_due_date_to")
+    new_due = preview.get("new_due_date") or "—"
+    new_to = preview.get("new_due_date_to")
+
+    current_label = f"{current} → {current_to}" if current_to else current
+    new_label = f"{new_due} → {new_to}" if new_to else new_due
+
+    with PrefabApp(state={"preview": preview}, css_class="p-4") as app, Card():
+        with CardHeader(), Row(gap=2):
+            CardTitle(content=f"Preview: due date for order {order_id}")
+            Badge(label="PREVIEW", variant="secondary")
+
+        with CardContent(), Column(gap=3):
+            _summary_chip(summary)
+            Separator()
+            with Row(gap=3):
+                with Column(gap=1):
+                    Muted(content="Current")
+                    Text(content=current_label)
+                Text(content="→")
+                with Column(gap=1):
+                    Muted(content="Proposed")
+                    Text(content=new_label)
+
+        with CardFooter(), Row(gap=2):
+            Button(
+                label="Confirm due date",
+                variant="default",
+                on_click=SendMessage(
+                    f"Update order {order_id} due date with confirm=true"
+                ),
+            )
+            Button(
+                label="Cancel",
+                variant="outline",
+                on_click=SendMessage("Cancel the due date change"),
+            )
+    return app
+
+
+def build_bulk_status_change_preview_ui(preview: dict[str, Any]) -> PrefabApp:
+    """Preview Card for ``bulk_update_order_status``.
+
+    Lists every order id about to be updated, the target status, and the
+    notification flags. Per-order context (current status) is intentionally
+    not fetched — that would be N round-trips today; once the ``id[]`` batch
+    fetch lands (issue #32) the UI can render a richer per-order table.
+    """
+    target_code = preview.get("target_status_code") or "—"
+    target_name = preview.get("target_status_name") or "—"
+    order_ids = preview.get("order_ids") or []
+    order_count = preview.get("order_count") or len(order_ids)
+    comment = preview.get("comment")
+    public = bool(preview.get("public"))
+    # Re-hydrate as the schema so its ``recipients_text`` is the single source
+    # of truth for both the UI and the markdown fallback rendered by orders.py.
+    from statuspro_mcp.tools.schemas import BulkStatusChangePreview as _BSP
+
+    recipients_text = _BSP.model_validate(preview).recipients_text()
+
+    with PrefabApp(state={"preview": preview}, css_class="p-4") as app, Card():
+        with CardHeader(), Row(gap=2):
+            CardTitle(content=f"Preview: bulk status change ({order_count} orders)")
+            Badge(label="PREVIEW", variant="secondary")
+
+        with CardContent(), Column(gap=3):
+            with Row(gap=2):
+                Muted(content="Target status:")
+                Badge(label=f"{target_name} · {target_code}", variant="info")
+            Separator()
+            Metric(label="Orders affected", value=str(order_count))
+            # Show the first ~10 ids inline; agents can ask for full list if needed.
+            ids_preview = ", ".join(str(i) for i in order_ids[:10])
+            if len(order_ids) > 10:
+                ids_preview += f", … (+{len(order_ids) - 10} more)"
+            Muted(content=f"IDs: {ids_preview}")
+
+            if comment:
+                Separator()
+                with Row(gap=2):
+                    Muted(content="Comment:")
+                    Text(content=comment)
+                    Badge(
+                        label="public" if public else "private",
+                        variant="info" if public else "outline",
+                    )
+
+            Separator()
+            Metric(label="Emails to", value=recipients_text)
+
+        with CardFooter(), Row(gap=2):
+            Button(
+                label=f"Confirm bulk update ({order_count})",
+                variant="default",
+                on_click=SendMessage(
+                    f"Bulk update {order_count} orders to status "
+                    f"{target_code} with confirm=true"
+                ),
+            )
+            Button(
+                label="Cancel",
+                variant="outline",
+                on_click=SendMessage("Cancel the bulk update"),
+            )
+    return app
+
+
 __all__ = [
+    "build_bulk_status_change_preview_ui",
+    "build_comment_preview_ui",
+    "build_due_date_change_preview_ui",
     "build_order_detail_ui",
     "build_orders_table_ui",
     "build_status_change_preview_ui",

--- a/statuspro_mcp_server/src/statuspro_mcp/tools/schemas.py
+++ b/statuspro_mcp_server/src/statuspro_mcp/tools/schemas.py
@@ -205,9 +205,119 @@ class StatusChangeResult(BaseModel):
     message: str | None = None
 
 
+class CommentResult(BaseModel):
+    """Execution result for ``add_order_comment`` with ``confirm=True``."""
+
+    action: Literal["add_order_comment"] = "add_order_comment"
+    confirmed: Literal[True] = True
+    order_id: int
+    success: bool
+    http_status: int
+    message: str | None = None
+
+
+class DueDateChangeResult(BaseModel):
+    """Execution result for ``update_order_due_date`` with ``confirm=True``."""
+
+    action: Literal["update_order_due_date"] = "update_order_due_date"
+    confirmed: Literal[True] = True
+    order_id: int
+    new_due_date: str
+    new_due_date_to: str | None = None
+    success: bool
+    http_status: int
+    message: str | None = None
+
+
+class BulkStatusChangeResult(BaseModel):
+    """Execution result for ``bulk_update_order_status`` with ``confirm=True``."""
+
+    action: Literal["bulk_update_order_status"] = "bulk_update_order_status"
+    confirmed: Literal[True] = True
+    order_count: int
+    target_status_code: str
+    success: bool
+    http_status: int
+    note: str | None = None
+    message: str | None = None
+
+
+class CommentPreview(BaseModel):
+    """Preview payload for ``add_order_comment`` with ``confirm=False``.
+
+    Includes the current ``order_summary`` so the preview UI can show
+    "you are about to comment on order #1188 (In Production)" rather than
+    just an opaque order id.
+    """
+
+    action: Literal["add_order_comment"] = "add_order_comment"
+    confirmed: Literal[False] = False
+    order_id: int
+    order_summary: OrderSummary
+    comment: str
+    public: bool
+
+
+class DueDateChangePreview(BaseModel):
+    """Preview payload for ``update_order_due_date`` with ``confirm=False``.
+
+    Surfaces the current vs. proposed due_date side-by-side via the order
+    summary plus the proposed new values.
+    """
+
+    action: Literal["update_order_due_date"] = "update_order_due_date"
+    confirmed: Literal[False] = False
+    order_id: int
+    order_summary: OrderSummary
+    current_due_date: str | None = None
+    current_due_date_to: str | None = None
+    new_due_date: str
+    new_due_date_to: str | None = None
+
+
+class BulkStatusChangePreview(BaseModel):
+    """Preview payload for ``bulk_update_order_status`` with ``confirm=False``.
+
+    Lists every order id that will be affected (capped at 50 by the API),
+    the target status code/name, and notification flags. We don't expand
+    each order_id to a full summary — that would be N round-trips today;
+    once the ``id[]`` batch fetch lands the UI can be enriched.
+    """
+
+    action: Literal["bulk_update_order_status"] = "bulk_update_order_status"
+    confirmed: Literal[False] = False
+    order_ids: list[int]
+    order_count: int
+    target_status_code: str
+    target_status_name: str | None = None
+    comment: str | None = None
+    public: bool
+    email_customer: bool
+    email_additional: bool
+
+    def recipients_text(self) -> str:
+        """Human-readable list of who will receive notification emails.
+
+        Mirrors ``StatusChangePreview.recipients_text`` so the UI builders
+        can share rendering logic.
+        """
+        recipients: list[str] = []
+        if self.email_customer:
+            recipients.append("customer")
+        if self.email_additional:
+            recipients.append("additional contacts")
+        return ", ".join(recipients) or "nobody"
+
+
 __all__ = [
+    "BulkStatusChangePreview",
+    "BulkStatusChangeResult",
+    "CommentPreview",
+    "CommentResult",
     "ConfirmationResult",
     "ConfirmationSchema",
+    "DueDateChangePreview",
+    "DueDateChangeResult",
     "HistoryEntry",
     "OrderDetail",
     "OrderHistoryPage",

--- a/statuspro_mcp_server/src/statuspro_mcp/tools/schemas.py
+++ b/statuspro_mcp_server/src/statuspro_mcp/tools/schemas.py
@@ -193,11 +193,18 @@ class StatusChangePreview(BaseModel):
 
 
 class StatusChangeResult(BaseModel):
-    """Execution result returned when ``update_order_status`` is called with
-    ``confirm=True``."""
+    """Execution result for ``update_order_status`` after the confirm step.
+
+    ``confirmed`` reflects whether the user actually accepted the elicitation:
+    ``True`` for the confirm-and-execute path, ``False`` when the user
+    declined or cancelled (in which case ``success`` and ``http_status`` will
+    also be falsy / zero). Declined results are still emitted as this type so
+    structured-content consumers can distinguish "confirmed but failed" from
+    "user declined".
+    """
 
     action: Literal["update_order_status"] = "update_order_status"
-    confirmed: Literal[True] = True
+    confirmed: bool = True
     order_id: int
     new_status_code: str
     success: bool
@@ -206,10 +213,15 @@ class StatusChangeResult(BaseModel):
 
 
 class CommentResult(BaseModel):
-    """Execution result for ``add_order_comment`` with ``confirm=True``."""
+    """Execution result for ``add_order_comment``.
+
+    See ``StatusChangeResult`` for ``confirmed`` semantics — the same model is
+    returned for the confirm-and-execute path and the declined path, with
+    ``confirmed=False`` set on the latter.
+    """
 
     action: Literal["add_order_comment"] = "add_order_comment"
-    confirmed: Literal[True] = True
+    confirmed: bool = True
     order_id: int
     success: bool
     http_status: int
@@ -217,10 +229,13 @@ class CommentResult(BaseModel):
 
 
 class DueDateChangeResult(BaseModel):
-    """Execution result for ``update_order_due_date`` with ``confirm=True``."""
+    """Execution result for ``update_order_due_date``.
+
+    See ``StatusChangeResult`` for ``confirmed`` semantics.
+    """
 
     action: Literal["update_order_due_date"] = "update_order_due_date"
-    confirmed: Literal[True] = True
+    confirmed: bool = True
     order_id: int
     new_due_date: str
     new_due_date_to: str | None = None
@@ -230,10 +245,13 @@ class DueDateChangeResult(BaseModel):
 
 
 class BulkStatusChangeResult(BaseModel):
-    """Execution result for ``bulk_update_order_status`` with ``confirm=True``."""
+    """Execution result for ``bulk_update_order_status``.
+
+    See ``StatusChangeResult`` for ``confirmed`` semantics.
+    """
 
     action: Literal["bulk_update_order_status"] = "bulk_update_order_status"
-    confirmed: Literal[True] = True
+    confirmed: bool = True
     order_count: int
     target_status_code: str
     success: bool

--- a/statuspro_mcp_server/tests/tools/test_prefab_ui.py
+++ b/statuspro_mcp_server/tests/tools/test_prefab_ui.py
@@ -17,6 +17,9 @@ import json
 
 from prefab_ui.app import PrefabApp
 from statuspro_mcp.tools.prefab_ui import (
+    build_bulk_status_change_preview_ui,
+    build_comment_preview_ui,
+    build_due_date_change_preview_ui,
     build_order_detail_ui,
     build_orders_table_ui,
     build_status_change_preview_ui,
@@ -165,3 +168,122 @@ def test_build_status_change_preview_ui_invalid_transition_hides_confirm():
     # Viable codes surface in the warning text so the agent can self-correct.
     assert "st000003" in serialized
     assert "st000004" in serialized
+
+
+def test_build_comment_preview_ui_renders_with_confirm_action():
+    """Comment preview shows the order context, the comment body + visibility,
+    and a Confirm button that fires the confirm=true follow-up.
+    """
+    app = build_comment_preview_ui(
+        {
+            "order_id": 1188,
+            "order_summary": {
+                "id": 1188,
+                "name": "#1188",
+                "order_number": "1188",
+                "status_name": "In Production",
+            },
+            "comment": "Customer asked about ETA.",
+            "public": False,
+        },
+    )
+    serialized = json.dumps(_envelope(app))
+    assert "confirm=true" in serialized
+    assert "Customer asked about ETA." in serialized
+    assert "private" in serialized  # visibility badge
+    # The order context surfaces so the agent isn't commenting blind.
+    assert "1188" in serialized
+
+
+def test_build_comment_preview_ui_public_visibility_renders():
+    """Public flag flips the badge variant and label."""
+    app = build_comment_preview_ui(
+        {
+            "order_id": 1,
+            "order_summary": {
+                "id": 1,
+                "name": "#1",
+                "order_number": "1",
+                "status_name": None,
+            },
+            "comment": "Shipped today.",
+            "public": True,
+        },
+    )
+    serialized = json.dumps(_envelope(app))
+    assert "public" in serialized
+
+
+def test_build_due_date_change_preview_ui_shows_before_after():
+    """Due date preview side-by-sides current vs. proposed so the delta is
+    obvious before confirmation. Without this test, a regression that
+    accidentally hides the current value passes silently.
+    """
+    app = build_due_date_change_preview_ui(
+        {
+            "order_id": 1188,
+            "order_summary": {
+                "id": 1188,
+                "name": "#1188",
+                "order_number": "1188",
+                "status_name": "In Production",
+            },
+            "current_due_date": "2026-03-15",
+            "current_due_date_to": None,
+            "new_due_date": "2026-03-22",
+            "new_due_date_to": "2026-03-24",
+        },
+    )
+    serialized = json.dumps(_envelope(app))
+    assert "2026-03-15" in serialized  # current
+    assert "2026-03-22" in serialized  # new
+    assert "2026-03-24" in serialized  # new range end
+    assert "confirm=true" in serialized
+
+
+def test_build_bulk_status_change_preview_ui_shows_count_and_target():
+    """Bulk preview must surface the affected count + target status code so
+    the agent can sanity-check before confirming a 50-order mutation.
+    """
+    app = build_bulk_status_change_preview_ui(
+        {
+            "order_ids": list(range(1, 26)),  # 25 ids
+            "order_count": 25,
+            "target_status_code": "st000003",
+            "target_status_name": "Shipped",
+            "comment": None,
+            "public": False,
+            "email_customer": True,
+            "email_additional": False,
+        },
+    )
+    serialized = json.dumps(_envelope(app))
+    assert "25" in serialized  # order count
+    assert "st000003" in serialized  # target code
+    assert "Shipped" in serialized  # target name (resolved from catalog)
+    assert "confirm=true" in serialized
+    # Recipients line should include "customer" but not "additional contacts"
+    # since email_additional=False.
+    assert "customer" in serialized
+
+
+def test_build_bulk_status_change_preview_ui_truncates_long_id_list():
+    """When more than 10 ids are bulk-updated, the UI must truncate the
+    inline ids preview with a "+N more" hint rather than dumping all 50.
+    """
+    app = build_bulk_status_change_preview_ui(
+        {
+            "order_ids": list(range(1, 51)),  # 50 ids — the API max
+            "order_count": 50,
+            "target_status_code": "st000003",
+            "target_status_name": "Shipped",
+            "comment": None,
+            "public": False,
+            "email_customer": True,
+            "email_additional": True,
+        },
+    )
+    serialized = json.dumps(_envelope(app))
+    # First 10 ids visible (1, 2, ..., 10); last id (50) hidden behind "+40 more"
+    assert "+40 more" in serialized
+    assert "50" in serialized  # the count, not the id

--- a/statuspro_mcp_server/tests/tools/test_result_schemas.py
+++ b/statuspro_mcp_server/tests/tools/test_result_schemas.py
@@ -1,0 +1,78 @@
+"""Tests for the structured-content shape of mutation result schemas.
+
+Pins the contract that the four result types (StatusChangeResult,
+CommentResult, DueDateChangeResult, BulkStatusChangeResult) accept
+``confirmed=False`` for the user-declined path. Before the fix in
+PR #46 follow-up, these all hard-coded ``confirmed: Literal[True]``,
+which made structured output claim the action was confirmed even when
+the user declined — misleading for downstream consumers.
+"""
+
+from __future__ import annotations
+
+import pytest
+from statuspro_mcp.tools.schemas import (
+    BulkStatusChangeResult,
+    CommentResult,
+    DueDateChangeResult,
+    StatusChangeResult,
+)
+
+
+@pytest.mark.unit
+class TestResultSchemasAcceptDeclinedConfirmation:
+    """Each result schema must accept confirmed=False so the declined
+    elicitation path can be represented accurately in structured output.
+    """
+
+    def test_status_change_result_default_confirmed_true(self):
+        """The success path defaults to confirmed=True (backwards compatible)."""
+        result = StatusChangeResult(
+            order_id=1, new_status_code="st000003", success=True, http_status=200
+        )
+        assert result.confirmed is True
+
+    def test_status_change_result_declined_path(self):
+        """Declined elicitation surfaces confirmed=False alongside success=False."""
+        result = StatusChangeResult(
+            confirmed=False,
+            order_id=1,
+            new_status_code="st000003",
+            success=False,
+            http_status=0,
+            message="User declined",
+        )
+        assert result.confirmed is False
+        assert result.success is False
+
+    def test_comment_result_declined_path(self):
+        result = CommentResult(
+            confirmed=False,
+            order_id=1,
+            success=False,
+            http_status=0,
+            message="User cancelled",
+        )
+        assert result.confirmed is False
+
+    def test_due_date_change_result_declined_path(self):
+        result = DueDateChangeResult(
+            confirmed=False,
+            order_id=1,
+            new_due_date="2026-04-01",
+            success=False,
+            http_status=0,
+            message="User declined",
+        )
+        assert result.confirmed is False
+
+    def test_bulk_status_change_result_declined_path(self):
+        result = BulkStatusChangeResult(
+            confirmed=False,
+            order_count=10,
+            target_status_code="st000003",
+            success=False,
+            http_status=0,
+            message="User cancelled",
+        )
+        assert result.confirmed is False


### PR DESCRIPTION
## Summary

Closes #39.

Brings the three remaining mutations into the find/view/decide/mutate Prefab UI cluster from #20. Before this PR, only `update_order_status` had a typed preview schema and a Prefab UI; the other three returned ad-hoc `dict[str, Any]` previews and rendered as raw JSON in clients that fall back from Prefab.

## What changed

### New typed schemas in `statuspro_mcp/tools/schemas.py`

- `CommentPreview` / `CommentResult`
- `DueDateChangePreview` / `DueDateChangeResult`
- `BulkStatusChangePreview` / `BulkStatusChangeResult`

Each preview includes the order context (current status, current due date) where relevant so the agent can sanity-check before confirming without an extra round-trip.

### New Prefab UI builders in `tools/prefab_ui.py`

- `build_comment_preview_ui` — order chip + comment + visibility badge
- `build_due_date_change_preview_ui` — current vs. proposed dates side-by-side
- `build_bulk_status_change_preview_ui` — count + target + truncated id list (first 10 + "+N more" hint) so 50-id mutations don't blow context

All three mutations now register with `meta=UI_META` and return `ToolResult` from both preview and confirm branches.

### New markdown templates (preview + result per mutation, 6 total)

`comment_preview.md`, `comment_result.md`, `due_date_change_preview.md`, `due_date_change_result.md`, `bulk_status_change_preview.md`, `bulk_status_change_result.md`.

### Behavior changes worth knowing

- `add_order_comment` preview now fetches the order to surface the current status next to the proposed comment.
- `update_order_due_date` preview shows current → proposed dates side-by-side (catches "I meant the other date" mistakes early).
- `bulk_update_order_status` preview resolves the target status name from the catalog so the agent sees both the code and the human-readable name. **Per-order outcomes are still not surfaced** — that's separate work in #34.

## Test plan

- [x] `uv run poe check` — 231 tests pass (+5 new)
- [x] 5 new Prefab UI smoke tests pinning the action wiring + key text:
  - comment preview Confirm action + visibility badge
  - comment preview public-visibility variant
  - due-date before/after rendering
  - bulk preview count + target name + recipients
  - bulk preview "+N more" truncation past 10 ids
- [ ] Verify against live MCP / Claude Desktop: each mutation's preview renders the new card-shaped UI

## Workflow

Following the corrected workflow from #45: open PR → wait for CI → poll for Copilot review for ~5 min → address comments → merge. Will not merge until Copilot has had a chance to review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)