### PR TITLE
feat(spec): OpenAPI spec sync script + upstream snapshot

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -45,4 +45,5 @@ ignore: |
   *.egg-info/
   statuspro_public_api_client/generated/
   docs/statuspro-openapi.yaml
+  docs/statuspro-openapi.upstream.yaml
   pnpm-lock.yaml

--- a/docs/statuspro-openapi.upstream.yaml
+++ b/docs/statuspro-openapi.upstream.yaml
@@ -1,0 +1,868 @@
+# AUTO-GENERATED — DO NOT EDIT. Regenerate with: uv run poe sync-openapi-spec
+# Upstream: https://orderstatuspro.com/api/openapi.json
+# This is the unmerged upstream view; the local fork lives at
+# docs/statuspro-openapi.yaml. Diff this file against the fork to see
+# what changed upstream since last sync.
+openapi: 3.1.0
+info:
+  description: Use this API to retrieve and update the status of an order.
+  license:
+    identifier: LicenseRef-Proprietary
+    name: Proprietary
+  title: StatusPro API
+  version: 1.0.0
+servers:
+- description: Production
+  url: https://app.orderstatuspro.com/api/v1
+security:
+- bearerAuth: []
+tags:
+- description: Order retrieval, status updates, comments, due dates, and lookup operations.
+  name: Orders
+- description: Status definition and viable-status listing operations.
+  name: Statuses
+paths:
+  /orders:
+    get:
+      description: Limited to 60 requests per minute.
+      operationId: listOrders
+      parameters:
+      - description: Filter by partial match against order name, order number, customer name, or customer
+          email.
+        in: query
+        name: search
+        required: false
+        schema:
+          type: string
+      - description: Filter by a single status code like st000002.
+        in: query
+        name: status_code
+        required: false
+        schema:
+          maxLength: 8
+          minLength: 8
+          type: string
+      - description: Filter by tags that must all be present using repeated query params such as tags[]=commercial&tags[]=commercial-lease.
+        examples:
+          allTags:
+            summary: Only orders containing every tag
+            value:
+            - commercial
+            - commercial-lease
+        explode: true
+        in: query
+        name: tags[]
+        required: false
+        schema:
+          items:
+            type: string
+          type: array
+        style: form
+      - description: Filter by tags where any listed tag may be present using repeated query params such
+          as tags_any[]=commercial&tags_any[]=commercial-flooring.
+        examples:
+          anyTags:
+            summary: Orders matching any listed tag
+            value:
+            - commercial-flooring
+            - commercial-rental
+        explode: true
+        in: query
+        name: tags_any[]
+        required: false
+        schema:
+          items:
+            type: string
+          type: array
+        style: form
+      - description: 'Filter by one or more financial statuses using repeated query params such as financial_status[]=partially_paid&financial_status[]=pending.
+          Accepted values: paid, partially_paid, partially_refunded, refunded, voided, pending, authorized,
+          unpaid.'
+        examples:
+          dueStatuses:
+            summary: Capture all due orders
+            value:
+            - partially_paid
+            - pending
+            - unpaid
+        explode: true
+        in: query
+        name: financial_status[]
+        required: false
+        schema:
+          items:
+            enum:
+            - paid
+            - partially_paid
+            - partially_refunded
+            - refunded
+            - voided
+            - pending
+            - authorized
+            - unpaid
+            type: string
+          type: array
+        style: form
+      - description: 'Filter by one or more fulfillment statuses using repeated query params such as fulfillment_status[]=fulfilled.
+          Accepted values: unfulfilled, partial, restocked, fulfilled.'
+        examples:
+          fulfilledOnly:
+            summary: Only fulfilled orders
+            value:
+            - fulfilled
+        explode: true
+        in: query
+        name: fulfillment_status[]
+        required: false
+        schema:
+          items:
+            enum:
+            - unfulfilled
+            - partial
+            - restocked
+            - fulfilled
+            type: string
+          type: array
+        style: form
+      - description: When true, excludes orders where cancelled_at is set.
+        example: true
+        in: query
+        name: exclude_cancelled
+        required: false
+        schema:
+          type: boolean
+      - description: Filter to orders with a due date on or after this `YYYY-MM-DD` date.
+        in: query
+        name: due_date_from
+        required: false
+        schema:
+          format: date
+          type: string
+      - description: Filter to orders with a due date on or before this `YYYY-MM-DD` date.
+        in: query
+        name: due_date_to
+        required: false
+        schema:
+          format: date
+          type: string
+      - description: Number of orders to return per page. Defaults to 15. Maximum 100.
+        in: query
+        name: per_page
+        required: false
+        schema:
+          default: 15
+          maximum: 100
+          minimum: 1
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              example:
+                data:
+                - customer:
+                    email: jon@example.com
+                    locale: en
+                    name: Jon Smith
+                  due_date: '2026-03-15T00:00:00+00:00'
+                  due_date_to: '2026-03-17T00:00:00+00:00'
+                  history_count: 4
+                  id: 6110375248088
+                  name: '#1188'
+                  order_number: '1188'
+                  status:
+                    auto_change_at: null
+                    code: st000002
+                    color: '#F59E0B'
+                    description: Order being handcrafted in the workshop
+                    is_set: true
+                    name: In Production
+                    public: true
+                    public_name: Crafting With Care
+                    set_at: '2026-03-12T10:14:00+00:00'
+                meta:
+                  current_page: 1
+                  from: 1
+                  last_page: 1
+                  per_page: 15
+                  to: 1
+                  total: 1
+              schema:
+                $ref: '#/components/schemas/OrderListResponse'
+          description: Success
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableEntity'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+      summary: Retrieve a paginated list of orders
+      tags:
+      - Orders
+  /orders/bulk-status:
+    post:
+      description: Limited to 5 requests per minute.
+      operationId: bulkUpdateOrderStatus
+      requestBody:
+        content:
+          application/json:
+            example:
+              comment: Batch moved to shipped
+              email_additional: false
+              email_customer: true
+              order_ids:
+              - 6110375248088
+              - 6110375248089
+              public: false
+              status_code: st000003
+            schema:
+              $ref: '#/components/schemas/BulkStatusUpdateRequest'
+        required: true
+      responses:
+        '202':
+          content:
+            application/json:
+              example:
+                count: 2
+                limit: 50
+                message: Bulk status update queued.
+              schema:
+                $ref: '#/components/schemas/BulkStatusUpdateResponse'
+          description: Accepted
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '422':
+          $ref: '#/components/responses/UnprocessableEntity'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+      summary: Queue a bulk status update for up to 50 orders
+      tags:
+      - Orders
+  /orders/lookup:
+    get:
+      description: Limited to 60 requests per minute.
+      operationId: lookupOrder
+      parameters:
+      - description: 'Order number or name (for example: 1188 or #1188).'
+        in: query
+        name: number
+        required: true
+        schema:
+          type: string
+      - description: Customer email address.
+        in: query
+        name: email
+        required: true
+        schema:
+          format: email
+          type: string
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrderResponse'
+          description: Success
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+      summary: Retrieve an order by order number and customer email
+      tags:
+      - Orders
+  /orders/{order}:
+    get:
+      description: Limited to 60 requests per minute.
+      operationId: getOrder
+      parameters:
+      - description: The ID of the order.
+        in: path
+        name: order
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OrderResponse'
+          description: Success
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+      summary: Retrieve details of a specific order
+      tags:
+      - Orders
+  /orders/{order}/comment:
+    post:
+      description: Limited to 60 requests per minute.
+      operationId: addOrderComment
+      parameters:
+      - description: The ID of the order.
+        in: path
+        name: order
+        required: true
+        schema:
+          type: integer
+      requestBody:
+        content:
+          application/json:
+            example:
+              comment: This is a comment
+              public: true
+            schema:
+              $ref: '#/components/schemas/AddOrderCommentRequest'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              example:
+                message: Order comment added!
+              schema:
+                $ref: '#/components/schemas/MessageResponse'
+          description: Success
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '422':
+          $ref: '#/components/responses/UnprocessableEntity'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+      summary: Add a comment to the order
+      tags:
+      - Orders
+  /orders/{order}/due-date:
+    post:
+      description: Limited to 60 requests per minute.
+      operationId: setOrderDueDate
+      parameters:
+      - description: The ID of the order.
+        in: path
+        name: order
+        required: true
+        schema:
+          type: integer
+      requestBody:
+        content:
+          application/json:
+            example:
+              due_date: '2026-02-10'
+              due_date_to: '2026-02-12'
+            schema:
+              $ref: '#/components/schemas/SetDueDateRequest'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              example:
+                message: Order due date set!
+              schema:
+                $ref: '#/components/schemas/MessageResponse'
+          description: Success
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '422':
+          $ref: '#/components/responses/UnprocessableEntity'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+      summary: Set a due date on the order
+      tags:
+      - Orders
+  /orders/{order}/status:
+    post:
+      description: Limited to 60 requests per minute.
+      operationId: updateOrderStatus
+      parameters:
+      - description: The ID of the order.
+        in: path
+        name: order
+        required: true
+        schema:
+          type: integer
+      requestBody:
+        content:
+          application/json:
+            example:
+              comment: This is a comment
+              email_additional: true
+              email_customer: true
+              public: true
+              status_code: st000002
+            schema:
+              $ref: '#/components/schemas/UpdateOrderStatusRequest'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              example:
+                message: Order status updated successfully!
+              schema:
+                $ref: '#/components/schemas/MessageResponse'
+          description: Success
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '422':
+          $ref: '#/components/responses/UnprocessableEntity'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+      summary: Update an order status
+      tags:
+      - Orders
+  /orders/{order}/viable-statuses:
+    get:
+      description: Limited to 60 requests per minute.
+      operationId: getViableStatuses
+      parameters:
+      - description: The ID of the order.
+        in: path
+        name: order
+        required: true
+        schema:
+          type: integer
+      responses:
+        '200':
+          content:
+            application/json:
+              example:
+              - code: st000002
+                color: pink
+                description: Order being handcrafted in the workshop
+                name: In Production
+              - code: st000003
+                color: green
+                description: Safely packed and dispatched
+                name: Shipped
+              schema:
+                items:
+                  $ref: '#/components/schemas/ViableStatus'
+                type: array
+          description: Success
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+      summary: Get viable statuses for an order
+      tags:
+      - Orders
+      - Statuses
+  /statuses:
+    get:
+      description: Limited to 60 requests per minute.
+      operationId: getStatuses
+      responses:
+        '200':
+          content:
+            application/json:
+              example:
+              - code: st000001
+                color: gray
+                description: We have received your order.
+                name: Order Received
+              - code: st000002
+                color: pink
+                description: Your order is being handcrafted in the workshop.
+                name: In Production
+              - code: st000003
+                color: green
+                description: Order has been shipped and is on its way.
+                name: Shipped
+              schema:
+                items:
+                  $ref: '#/components/schemas/StatusDefinition'
+                type: array
+          description: Success
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '429':
+          $ref: '#/components/responses/TooManyRequests'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+      summary: Get all defined statuses for your account
+      tags:
+      - Statuses
+components:
+  responses:
+    BadRequest:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+      description: Bad Request. The request was malformed or missing required headers.
+    InternalServerError:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+      description: Internal Server Error. An unexpected error occurred.
+    NotFound:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+      description: Not Found. The requested resource does not exist.
+    TooManyRequests:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+      description: Too Many Requests. The request was rate limited. Wait before retrying.
+    UnprocessableEntity:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ValidationErrorResponse'
+      description: Unprocessable Entity. The request was well-formed but contains invalid data or failed
+        validation.
+  schemas:
+    AddOrderCommentRequest:
+      properties:
+        comment:
+          maxLength: 1000
+          minLength: 3
+          type: string
+        public:
+          default: false
+          type: boolean
+      required:
+      - comment
+      type: object
+    BulkStatusUpdateRequest:
+      properties:
+        comment:
+          type: string
+        due_date:
+          format: date
+          type: string
+        email_additional:
+          default: true
+          type: boolean
+        email_customer:
+          default: true
+          type: boolean
+        order_ids:
+          items:
+            type: integer
+          maxItems: 50
+          minItems: 1
+          type: array
+        public:
+          default: false
+          type: boolean
+        send_at:
+          description: Unix timestamp to schedule status emails.
+          type: integer
+        status_code:
+          type: string
+      required:
+      - order_ids
+      - status_code
+      type: object
+    BulkStatusUpdateResponse:
+      properties:
+        count:
+          type: integer
+        limit:
+          type: integer
+        message:
+          type: string
+      required:
+      - message
+      - count
+      - limit
+      type: object
+    Customer:
+      properties:
+        email:
+          format: email
+          type: string
+        locale:
+          type: string
+        name:
+          type: string
+      type: object
+    ErrorResponse:
+      properties:
+        message:
+          type: string
+      type: object
+    HistoryItem:
+      properties:
+        comment:
+          type:
+          - string
+          - 'null'
+        comment_is_public:
+          type: boolean
+        created_at:
+          format: date-time
+          type: string
+        event:
+          type: string
+        mail_log:
+          anyOf:
+          - $ref: '#/components/schemas/MailLog'
+          - type: 'null'
+        status:
+          anyOf:
+          - $ref: '#/components/schemas/Status'
+          - type: 'null'
+      type: object
+    LocaleTranslation:
+      properties:
+        description:
+          type: string
+        name:
+          type: string
+      type: object
+    MailLog:
+      properties:
+        delivery_status:
+          type: string
+        from:
+          format: email
+          type: string
+        subject:
+          type: string
+        to:
+          format: email
+          type: string
+      type: object
+    MessageResponse:
+      properties:
+        message:
+          type: string
+      required:
+      - message
+      type: object
+    OrderListItem:
+      properties:
+        customer:
+          $ref: '#/components/schemas/Customer'
+        due_date:
+          format: date-time
+          type:
+          - string
+          - 'null'
+        due_date_to:
+          format: date-time
+          type:
+          - string
+          - 'null'
+        history_count:
+          type: integer
+        id:
+          type: integer
+        name:
+          type: string
+        order_number:
+          type: string
+        status:
+          $ref: '#/components/schemas/Status'
+      type: object
+    OrderListMeta:
+      properties:
+        current_page:
+          type: integer
+        from:
+          type:
+          - integer
+          - 'null'
+        last_page:
+          type: integer
+        per_page:
+          type: integer
+        to:
+          type:
+          - integer
+          - 'null'
+        total:
+          type: integer
+      type: object
+    OrderListResponse:
+      properties:
+        data:
+          items:
+            $ref: '#/components/schemas/OrderListItem'
+          type: array
+        meta:
+          $ref: '#/components/schemas/OrderListMeta'
+      required:
+      - data
+      - meta
+      type: object
+    OrderResponse:
+      properties:
+        customer:
+          $ref: '#/components/schemas/Customer'
+        due_date:
+          format: date-time
+          type:
+          - string
+          - 'null'
+        due_date_to:
+          format: date-time
+          type:
+          - string
+          - 'null'
+        history:
+          items:
+            $ref: '#/components/schemas/HistoryItem'
+          type: array
+        id:
+          type: integer
+        name:
+          type: string
+        order_number:
+          type: string
+        public_progress_timeline:
+          items:
+            $ref: '#/components/schemas/ProgressTimelineItem'
+          type: array
+        status:
+          $ref: '#/components/schemas/Status'
+      type: object
+    ProgressTimelineItem:
+      properties:
+        description:
+          type: string
+        name:
+          type: string
+        progress:
+          type: string
+        timestamp:
+          type:
+          - string
+          - 'null'
+      type: object
+    SetDueDateRequest:
+      properties:
+        due_date:
+          format: date
+          type:
+          - string
+          - 'null'
+        due_date_to:
+          format: date
+          type: string
+      required:
+      - due_date
+      type: object
+    Status:
+      properties:
+        auto_change_at:
+          format: date-time
+          type:
+          - string
+          - 'null'
+        code:
+          type: string
+        description:
+          type: string
+        is_set:
+          type: boolean
+        name:
+          type: string
+        public:
+          type: boolean
+        public_name:
+          type:
+          - string
+          - 'null'
+        set_at:
+          format: date-time
+          type:
+          - string
+          - 'null'
+        translations:
+          additionalProperties:
+            $ref: '#/components/schemas/LocaleTranslation'
+          type: object
+      type: object
+    StatusDefinition:
+      properties:
+        code:
+          type: string
+        color:
+          type: string
+        description:
+          type: string
+        name:
+          type: string
+      type: object
+    UpdateOrderStatusRequest:
+      properties:
+        comment:
+          type: string
+        email_additional:
+          default: true
+          type: boolean
+        email_customer:
+          default: true
+          type: boolean
+        public:
+          default: false
+          type: boolean
+        status_code:
+          type: string
+      required:
+      - status_code
+      type: object
+    ValidationErrorResponse:
+      properties:
+        errors:
+          additionalProperties:
+            items:
+              type: string
+            type: array
+          type: object
+        message:
+          type: string
+      type: object
+    ViableStatus:
+      properties:
+        code:
+          type: string
+        color:
+          type: string
+        description:
+          type: string
+        name:
+          type: string
+      type: object
+  securitySchemes:
+    bearerAuth:
+      bearerFormat: API Key
+      scheme: bearer
+      type: http

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -481,6 +481,7 @@ test-schema = "pytest -m schema_validation"  # Run schema validation tests only 
 regenerate-client = "python scripts/regenerate_client.py"
 generate-pydantic = "python scripts/generate_pydantic_models.py"
 regenerate-all = ["regenerate-client", "generate-pydantic"]
+sync-openapi-spec = "python scripts/sync_openapi_spec.py"
 validate-openapi = "openapi-spec-validator docs/statuspro-openapi.yaml"
 validate-openapi-redocly = "npx @redocly/cli lint docs/statuspro-openapi.yaml"
 

--- a/scripts/sync_openapi_spec.py
+++ b/scripts/sync_openapi_spec.py
@@ -32,6 +32,7 @@ import json
 import os
 import sys
 import urllib.error
+import urllib.parse
 import urllib.request
 from pathlib import Path
 from typing import Any
@@ -42,10 +43,24 @@ DEFAULT_UPSTREAM_URL = "https://orderstatuspro.com/api/openapi.json"
 DEFAULT_OUTPUT_PATH = (
     Path(__file__).resolve().parent.parent / "docs" / "statuspro-openapi.upstream.yaml"
 )
+ALLOWED_URL_SCHEMES = ("http", "https")
 
 
 def fetch_upstream_spec(url: str, *, timeout: int = 30) -> dict[str, Any]:
-    """Download the upstream OpenAPI spec as a parsed dict."""
+    """Download the upstream OpenAPI spec as a parsed dict.
+
+    The URL is configurable via env var, so validate the scheme to block
+    ``file://`` (which urllib accepts and would let a misconfigured env
+    var exfiltrate local files) and other non-HTTP schemes.
+    """
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme not in ALLOWED_URL_SCHEMES:
+        msg = (
+            f"Refusing to fetch from non-HTTP scheme {parsed.scheme!r}: {url}. "
+            f"Allowed schemes: {ALLOWED_URL_SCHEMES}."
+        )
+        raise ValueError(msg)
+
     print(f"Fetching upstream spec: {url}")
     try:
         req = urllib.request.Request(

--- a/scripts/sync_openapi_spec.py
+++ b/scripts/sync_openapi_spec.py
@@ -23,7 +23,8 @@ This script does NOT auto-merge upstream into the fork — the merge is a
 human judgment call (e.g. "did upstream rename a param we already added?").
 
 Configure the upstream URL with ``STATUSPRO_OPENAPI_URL`` if the public
-endpoint changes.
+endpoint changes. Configure the output path with ``STATUSPRO_OPENAPI_OUTPUT``
+to write the normalized upstream spec to a different file.
 """
 
 from __future__ import annotations
@@ -31,12 +32,11 @@ from __future__ import annotations
 import json
 import os
 import sys
-import urllib.error
 import urllib.parse
-import urllib.request
 from pathlib import Path
 from typing import Any
 
+import httpx
 import yaml
 
 DEFAULT_UPSTREAM_URL = "https://orderstatuspro.com/api/openapi.json"
@@ -46,12 +46,38 @@ DEFAULT_OUTPUT_PATH = (
 ALLOWED_URL_SCHEMES = ("http", "https")
 
 
-def fetch_upstream_spec(url: str, *, timeout: int = 30) -> dict[str, Any]:
+def _parse_body(body: bytes, *, content_type: str, url: str) -> dict[str, Any]:
+    """Parse the response body as JSON or YAML, with a clear error on failure."""
+
+    def _load_yaml() -> Any:
+        try:
+            return yaml.safe_load(body)
+        except (yaml.YAMLError, UnicodeDecodeError) as e:
+            print(
+                f"ERROR: failed to parse upstream OpenAPI spec as YAML from {url} "
+                f"(content-type: {content_type or 'unknown'}): {e}",
+                file=sys.stderr,
+            )
+            raise SystemExit(2) from e
+
+    if "json" in content_type.lower():
+        return json.loads(body)
+    if "yaml" in content_type.lower() or "yml" in content_type.lower():
+        return _load_yaml()
+    # Fall back: try JSON first (the documented endpoint serves JSON), then YAML.
+    try:
+        return json.loads(body)
+    except json.JSONDecodeError:
+        return _load_yaml()
+
+
+def fetch_upstream_spec(url: str, *, timeout: float = 30.0) -> dict[str, Any]:
     """Download the upstream OpenAPI spec as a parsed dict.
 
     The URL is configurable via env var, so validate the scheme to block
-    ``file://`` (which urllib accepts and would let a misconfigured env
-    var exfiltrate local files) and other non-HTTP schemes.
+    non-HTTP fetches up front. ``httpx`` itself rejects ``file://`` URLs,
+    but the explicit allow-list documents the contract and protects against
+    any future transport that might accept them.
     """
     parsed = urllib.parse.urlparse(url)
     if parsed.scheme not in ALLOWED_URL_SCHEMES:
@@ -63,32 +89,23 @@ def fetch_upstream_spec(url: str, *, timeout: int = 30) -> dict[str, Any]:
 
     print(f"Fetching upstream spec: {url}")
     try:
-        req = urllib.request.Request(
+        resp = httpx.get(
             url,
             headers={
                 "Accept": "application/json",
                 "User-Agent": "statuspro-openapi-client/sync",
             },
+            timeout=timeout,
+            follow_redirects=True,
         )
-        with urllib.request.urlopen(req, timeout=timeout) as resp:
-            content_type = resp.headers.get("content-type", "")
-            body = resp.read()
-    except urllib.error.HTTPError as e:
-        print(f"ERROR: HTTP {e.code} fetching {url}: {e.reason}", file=sys.stderr)
-        raise SystemExit(2) from e
-    except urllib.error.URLError as e:
-        print(f"ERROR: failed to fetch {url}: {e.reason}", file=sys.stderr)
+        resp.raise_for_status()
+    except httpx.HTTPError as e:
+        print(f"ERROR fetching {url}: {e}", file=sys.stderr)
         raise SystemExit(2) from e
 
-    if "json" in content_type.lower():
-        return json.loads(body)
-    if "yaml" in content_type.lower() or "yml" in content_type.lower():
-        return yaml.safe_load(body)
-    # Fall back: try JSON first (the documented endpoint serves JSON), then YAML.
-    try:
-        return json.loads(body)
-    except json.JSONDecodeError:
-        return yaml.safe_load(body)
+    return _parse_body(
+        resp.content, content_type=resp.headers.get("content-type", ""), url=url
+    )
 
 
 # OpenAPI conventional top-level key order. Following this at the document
@@ -190,7 +207,7 @@ def main() -> int:
         f"# docs/statuspro-openapi.yaml. Diff this file against the fork to see\n"
         f"# what changed upstream since last sync.\n"
     )
-    output_path.write_text(banner + yaml_text)
+    output_path.write_text(banner + yaml_text, encoding="utf-8")
     print(f"\nWrote {output_path} ({output_path.stat().st_size} bytes)")
     return 0
 

--- a/scripts/sync_openapi_spec.py
+++ b/scripts/sync_openapi_spec.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Pull the upstream StatusPro OpenAPI spec, normalize to YAML for diffing.
+
+The local spec at ``docs/statuspro-openapi.yaml`` is a fork: we evolve it
+locally to add params/endpoints the upstream spec doesn't yet declare (e.g.
+the ``page`` query parameter for ``GET /orders`` added in #27). This script
+fetches the canonical upstream spec, converts it to YAML with deterministic
+ordering and width, and writes it to ``docs/statuspro-openapi.upstream.yaml``
+so a regular ``git diff`` against the local fork surfaces upstream deltas
+cleanly.
+
+The intended workflow:
+
+1. ``uv run poe sync-openapi-spec`` — pulls latest upstream into
+   ``docs/statuspro-openapi.upstream.yaml``.
+2. ``git diff docs/statuspro-openapi.upstream.yaml`` — see what changed
+   upstream since last sync.
+3. Reconcile interesting deltas into the local fork
+   (``docs/statuspro-openapi.yaml``) by hand.
+4. Run ``uv run poe regenerate-client`` to refresh the generated client.
+
+This script does NOT auto-merge upstream into the fork — the merge is a
+human judgment call (e.g. "did upstream rename a param we already added?").
+
+Configure the upstream URL with ``STATUSPRO_OPENAPI_URL`` if the public
+endpoint changes.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+DEFAULT_UPSTREAM_URL = "https://orderstatuspro.com/api/openapi.json"
+DEFAULT_OUTPUT_PATH = (
+    Path(__file__).resolve().parent.parent / "docs" / "statuspro-openapi.upstream.yaml"
+)
+
+
+def fetch_upstream_spec(url: str, *, timeout: int = 30) -> dict[str, Any]:
+    """Download the upstream OpenAPI spec as a parsed dict."""
+    print(f"Fetching upstream spec: {url}")
+    try:
+        req = urllib.request.Request(
+            url,
+            headers={
+                "Accept": "application/json",
+                "User-Agent": "statuspro-openapi-client/sync",
+            },
+        )
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            content_type = resp.headers.get("content-type", "")
+            body = resp.read()
+    except urllib.error.HTTPError as e:
+        print(f"ERROR: HTTP {e.code} fetching {url}: {e.reason}", file=sys.stderr)
+        raise SystemExit(2) from e
+    except urllib.error.URLError as e:
+        print(f"ERROR: failed to fetch {url}: {e.reason}", file=sys.stderr)
+        raise SystemExit(2) from e
+
+    if "json" in content_type.lower():
+        return json.loads(body)
+    if "yaml" in content_type.lower() or "yml" in content_type.lower():
+        return yaml.safe_load(body)
+    # Fall back: try JSON first (the documented endpoint serves JSON), then YAML.
+    try:
+        return json.loads(body)
+    except json.JSONDecodeError:
+        return yaml.safe_load(body)
+
+
+# OpenAPI conventional top-level key order. Following this at the document
+# root keeps the synced YAML readable to humans familiar with OpenAPI specs
+# AND keeps diffs against the local fork (which uses the same convention)
+# free of pure-reordering churn.
+_OPENAPI_TOP_LEVEL_ORDER = (
+    "openapi",
+    "info",
+    "jsonSchemaDialect",
+    "servers",
+    "security",
+    "tags",
+    "paths",
+    "webhooks",
+    "components",
+    "externalDocs",
+)
+
+
+def _ordered(d: dict[str, Any], preferred: tuple[str, ...]) -> dict[str, Any]:
+    """Return a new dict with keys in ``preferred`` order first, then the rest sorted."""
+    result: dict[str, Any] = {}
+    for key in preferred:
+        if key in d:
+            result[key] = d[key]
+    for key in sorted(d.keys()):
+        if key not in result:
+            result[key] = d[key]
+    return result
+
+
+def normalize(value: Any, *, _is_root: bool = False) -> Any:
+    """Recursively sort dict keys for deterministic YAML output.
+
+    At the document root, top-level keys follow OpenAPI convention
+    (``openapi``, ``info``, ``servers``, ``security``, ``tags``, ``paths``,
+    ``components``, ...) so the synced file reads like a normal OpenAPI doc
+    and diffs against the local fork show real content changes, not
+    reordering noise. Below the root, keys are sorted alphabetically — that
+    gives stable diffs across upstream regenerations even if the server
+    reshuffles dict ordering.
+
+    Lists keep their original order (path order, parameter order, etc. in
+    OpenAPI is positionally meaningful for at least some consumers).
+    """
+    if isinstance(value, dict):
+        if _is_root:
+            ordered = _ordered(value, _OPENAPI_TOP_LEVEL_ORDER)
+            return {k: normalize(ordered[k]) for k in ordered}
+        return {k: normalize(value[k]) for k in sorted(value.keys())}
+    if isinstance(value, list):
+        return [normalize(item) for item in value]
+    return value
+
+
+def dump_yaml(data: dict[str, Any]) -> str:
+    """Render a dict as YAML with settings that keep diffs minimal."""
+    return yaml.safe_dump(
+        data,
+        default_flow_style=False,  # block style — line-by-line diffs
+        sort_keys=False,  # we sort upstream of this; preserve our order
+        width=100,  # consistent line wrapping
+        allow_unicode=True,
+        indent=2,
+    )
+
+
+def main() -> int:
+    upstream_url = os.environ.get("STATUSPRO_OPENAPI_URL", DEFAULT_UPSTREAM_URL)
+    output_path_str = os.environ.get("STATUSPRO_OPENAPI_OUTPUT")
+    output_path = Path(output_path_str) if output_path_str else DEFAULT_OUTPUT_PATH
+
+    spec = fetch_upstream_spec(upstream_url)
+    if not isinstance(spec, dict):
+        print(
+            f"ERROR: upstream returned non-dict shape: {type(spec).__name__}",
+            file=sys.stderr,
+        )
+        return 2
+
+    info = spec.get("info") or {}
+    print(
+        f"Upstream: {info.get('title', '?')} v{info.get('version', '?')} "
+        f"(openapi {spec.get('openapi', '?')})"
+    )
+    print(f"  paths: {len(spec.get('paths') or {})}")
+    print(f"  schemas: {len((spec.get('components') or {}).get('schemas') or {})}")
+
+    normalized = normalize(spec, _is_root=True)
+    yaml_text = dump_yaml(normalized)
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    # Write a small banner so readers know this is auto-generated.
+    banner = (
+        "# AUTO-GENERATED — DO NOT EDIT. Regenerate with: uv run poe sync-openapi-spec\n"
+        f"# Upstream: {upstream_url}\n"
+        f"# This is the unmerged upstream view; the local fork lives at\n"
+        f"# docs/statuspro-openapi.yaml. Diff this file against the fork to see\n"
+        f"# what changed upstream since last sync.\n"
+    )
+    output_path.write_text(banner + yaml_text)
+    print(f"\nWrote {output_path} ({output_path.stat().st_size} bytes)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Addresses **#29** — establishes the **fork-and-sync** spec ownership model.

The local `docs/statuspro-openapi.yaml` is our fork of the upstream StatusPro spec. We evolve it locally for things upstream hasn't declared yet (the `page` parameter from #27 is the only such case today). Without tooling to detect upstream drift, local additions silently rot when upstream changes.

## What's in this PR

### `scripts/sync_openapi_spec.py` (new, registered as `poe sync-openapi-spec`)

- Fetches the canonical upstream spec from `https://orderstatuspro.com/api/openapi.json` (configurable via `STATUSPRO_OPENAPI_URL`)
- Normalizes JSON → YAML with deterministic ordering:
  - Top-level keys follow OpenAPI convention (`openapi`, `info`, `servers`, `security`, `tags`, `paths`, `components`, ...)
  - Nested keys sort alphabetically (stable diffs across server-side dict reshuffles)
  - List order preserved (positionally meaningful in OpenAPI)
- Writes to `docs/statuspro-openapi.upstream.yaml` with an auto-generated banner

### `docs/statuspro-openapi.upstream.yaml` (new)

The first synced snapshot. Committing this file lets `git diff` between commits show what changed upstream between sync points.

### `pyproject.toml`

New `sync-openapi-spec` poe task.

## Workflow

```
uv run poe sync-openapi-spec               # pull upstream
git diff docs/statuspro-openapi.upstream.yaml   # see what changed since last sync
# reconcile interesting deltas into docs/statuspro-openapi.yaml by hand
uv run poe regenerate-client               # refresh the generated Python client
```

## Local divergence today

Structurally diffing local fork vs upstream:

```
=== Paths only in LOCAL ===     (none)
=== Paths only in UPSTREAM ===  (none)
=== Parameters only in LOCAL === ('/orders', 'get', 'page', 'query')
=== Parameters only in UPSTREAM === (none)
=== Schemas only in LOCAL ===   (none)
=== Schemas only in UPSTREAM === (none)
```

Just the `page` parameter. Everything else matches upstream exactly.

## Test plan

- [x] `uv run poe sync-openapi-spec` runs cleanly, reports counts
- [x] `uv run poe agent-check` clean (formatter/linter happy with the script)
- [ ] Periodic CI workflow to auto-sync (deferred — file separate issue if wanted)

## Why no auto-merge

Spec divergence is a judgment call ("did upstream rename a param we've already added?"). The script intentionally does not auto-merge. The synced file gives a human the diff to review and reconcile by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)