### PR TITLE
chore(ci): add weekly upstream OpenAPI spec sync workflow

### DIFF
--- a/.github/workflows/sync-openapi-spec.yml
+++ b/.github/workflows/sync-openapi-spec.yml
@@ -1,0 +1,81 @@
+name: Sync upstream OpenAPI spec
+
+# Pull the canonical upstream OpenAPI spec from
+# https://orderstatuspro.com/api/openapi.json into
+# docs/statuspro-openapi.upstream.yaml. If anything changed, open a PR
+# with the diff so a human can decide whether to reconcile changes
+# into the local fork at docs/statuspro-openapi.yaml.
+#
+# This workflow does NOT auto-merge upstream into the fork — see
+# scripts/sync_openapi_spec.py for the rationale.
+
+on:
+  schedule:
+    # Mondays at 9:00 UTC — early enough in the week that any
+    # reconciliation work fits before Friday.
+    - cron: '0 9 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+          python-version: "3.14"
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Sync upstream spec
+        run: uv run poe sync-openapi-spec
+
+      - name: Detect changes
+        id: detect
+        run: |
+          if git diff --quiet docs/statuspro-openapi.upstream.yaml; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No upstream changes detected."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Upstream changed — will open a PR."
+            git diff --stat docs/statuspro-openapi.upstream.yaml
+          fi
+
+      - name: Open PR if upstream changed
+        if: steps.detect.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: chore/upstream-openapi-spec-sync
+          delete-branch: true
+          commit-message: |
+            chore(spec): sync upstream OpenAPI spec snapshot
+          title: "chore(spec): sync upstream OpenAPI spec snapshot"
+          body: |
+            Automated sync of `docs/statuspro-openapi.upstream.yaml` from
+            <https://orderstatuspro.com/api/openapi.json>.
+
+            **What this PR is:** the upstream-only view, refreshed.
+            Reviewing the diff shows what changed upstream since the
+            last sync.
+
+            **What this PR is NOT:** an auto-merge into the local fork
+            (`docs/statuspro-openapi.yaml`). Reconciliation is a human
+            judgment call — e.g. "did upstream rename a parameter we
+            already added?". After merging this PR, manually port any
+            relevant deltas into the local fork in a follow-up.
+
+            See [`scripts/sync_openapi_spec.py`](../blob/main/scripts/sync_openapi_spec.py)
+            for the workflow.
+          labels: |
+            area/spec
+            theme/tool-surface-redesign

--- a/.github/workflows/sync-openapi-spec.yml
+++ b/.github/workflows/sync-openapi-spec.yml
@@ -25,6 +25,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          # Always sync against main, regardless of which ref triggered the
+          # workflow. Manual `workflow_dispatch` from a feature branch
+          # would otherwise base the diff (and the PR) on that branch.
+          ref: main
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -55,6 +60,7 @@ jobs:
         if: steps.detect.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
+          base: main
           branch: chore/upstream-openapi-spec-sync
           delete-branch: true
           commit-message: |
@@ -74,7 +80,7 @@ jobs:
             already added?". After merging this PR, manually port any
             relevant deltas into the local fork in a follow-up.
 
-            See [`scripts/sync_openapi_spec.py`](../blob/main/scripts/sync_openapi_spec.py)
+            See [`scripts/sync_openapi_spec.py`](scripts/sync_openapi_spec.py)
             for the workflow.
           labels: |
             area/spec


### PR DESCRIPTION
## Summary

Deferred from #47. Runs the spec sync script automatically each week so upstream drift surfaces as a PR rather than a stale snapshot.

## Schedule

- **Weekly cron**: Mondays at 09:00 UTC (early enough that any reconciliation work fits before Friday)
- **Manual**: `workflow_dispatch` trigger from the Actions tab

## Behavior

1. Runs `uv run poe sync-openapi-spec` against the upstream URL.
2. Diffs `docs/statuspro-openapi.upstream.yaml` against the committed version on main.
3. If anything changed, opens a PR titled `chore(spec): sync upstream OpenAPI spec snapshot` on the `chore/upstream-openapi-spec-sync` branch.
4. **Does NOT auto-merge** into the local fork at `docs/statuspro-openapi.yaml` — that's a human judgment call (e.g. "did upstream rename a parameter we already added?"). After merging the auto-PR, manually port any deltas into the fork in a follow-up.

Uses `peter-evans/create-pull-request@v7` (idempotent — re-running with no further changes just updates the existing PR; deletes the branch when merged).

## Permissions

Needs `contents: write` and `pull-requests: write` to push the branch and open the PR. Minimum required by `create-pull-request`.

## Test plan

- [x] `uv run poe agent-check` (yamllint + format checks pass on the workflow file)
- [ ] Trigger manually post-merge via `workflow_dispatch` to verify the happy path with a real upstream fetch

🤖 Generated with [Claude Code](https://claude.com/claude-code)