### PR TITLE
docs: capture retro learnings — Copilot review wait + structural test asserts

### DIFF
--- a/.claude/skills/write-tests/SKILL.md
+++ b/.claude/skills/write-tests/SKILL.md
@@ -52,6 +52,7 @@ Core coverage must stay ≥ 87%.
 - [Async test] — must have `@pytest.mark.asyncio`. Don't forget the marker even when the test looks synchronous from inside.
 - [HTTP mocking] — use `httpx.MockTransport` with shared fixtures from `conftest.py`. Don't reinvent mocking per test module.
 - [Tabular cases] — use `@pytest.mark.parametrize` instead of duplicating bodies.
+- [Asserting on nested envelopes] — for tool results, Prefab payloads, response wrappers, and other nested-dict structures, write a small walker that extracts the specific node you care about (e.g., `_find_tool_calls(envelope) → list[dict]`) and assert on the extracted value. Avoid `repr(envelope)` substring or `"thing" in str(envelope)` checks — they pass via unrelated fields that happen to share keywords (e.g., a preview's `action` field can satisfy a substring check meant to verify a button's tool target). This bit us twice in PR #50/#52 review.
 - [Test reveals undocumented API behavior] — update CLAUDE.md "Known Pitfalls" so the next session doesn't rediscover it.
 
 ## RELATED

--- a/AGENT_WORKFLOW.md
+++ b/AGENT_WORKFLOW.md
@@ -545,6 +545,27 @@ gh pr checks
 # Should show all checks passing
 ```
 
+#### Wait for Copilot Review
+
+GitHub Copilot's automated review typically lands 2–5 minutes after a PR opens. **Do not
+merge before it lands** — Copilot regularly catches type-narrowing gaps, weak
+assertions, and edge cases that human review and CI miss. Merging early bypasses real
+feedback.
+
+```bash
+# Check whether Copilot has reviewed
+gh pr view <pr-number> --json reviews --jq '.reviews[] | select(.author.login == "copilot-pull-request-reviewer") | .state'
+```
+
+If Copilot has commented:
+
+```bash
+/review-pr <pr-number>   # Address each comment, push fixes, reply
+```
+
+Only merge once Copilot's findings are addressed (fixed in-branch, deferred with a
+tracked issue, or explicitly disagreed with in a reply).
+
 #### Merge
 
 ```bash


### PR DESCRIPTION
## Summary

Two findings from the `/harness retro` after today's MCP refactor session, captured as project-local doc/skill updates so future sessions don't re-learn them.

- **`AGENT_WORKFLOW.md` "Before Merge"** now has an explicit "Wait for Copilot Review" step. Mid-session today I had to be corrected on this after PRs #42, #43, #44 merged before Copilot landed; #45 was the retroactive cleanup. Document captures the wait window (2–5 min after PR open) and the `/review-pr` follow-up.
- **`/write-tests` skill** now calls out the structural-walker pattern for assertions on nested envelopes. `repr(envelope)` substring checks pass via unrelated fields (e.g. a preview's `action` field satisfying a substring meant to verify a button's `tool` target) — bit us twice in PR #50/#52 review.

The global side of the Copilot-review gap is filed upstream as [dougborg/harness-kit#24](https://github.com/dougborg/harness-kit/issues/24) — `poll-review.sh` should treat Copilot as a first-class reviewer so this fix lands once across all projects, not per-project.

## Test plan

- [ ] `uv run poe quick-check` passes locally
- [ ] Doc renders correctly in GitHub preview (markdown formatting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)