### PR TITLE
chore: align with katana-openapi-client safety + MCP fixes

### DIFF
--- a/.claude/skills/open-pr/SKILL.md
+++ b/.claude/skills/open-pr/SKILL.md
@@ -24,6 +24,7 @@ Ship a feature branch end-to-end: validate, self-review, push, create PR, wait f
 - **Use polling scripts for CI and review state** — never check review comments with `gh pr view --json`. That endpoint only returns top-level PR comments, not inline review comments attached to code lines. Use `poll-review.sh` which calls the correct API (`gh api repos/.../pulls/.../comments`).
 - **Never merge with unaddressed review comments** — every comment gets fixed, deferred with a tracked issue, or discussed. CI green does not override review feedback.
 - **No `--no-verify`** — never bypass commit hooks, type checkers, or linters. If a check fails, fix the cause.
+- **Push with the safe refspec, never the bare branch name** — use `git push -u origin HEAD:refs/heads/<branch-name>`, **not** `git push -u origin <branch-name>`. The bare form resolves the destination via the local branch's *upstream*. When a feature branch is created with `git checkout -b <name> origin/main`, its upstream is `origin/main` — and `git push -u origin <name>` then pushes straight to **`main`**, not to a new remote `<name>` ref. The pre-push guard at `scripts/pre-push-guard.sh` exists for this reason but does not fire from worktrees that haven't installed the repo hooks via `uv run pre-commit install`. Same rule applies to subsequent pushes (`git push --force-with-lease` after a rebase).
 
 ## STANDARD PATH
 
@@ -140,10 +141,11 @@ Note: This phase is optional and relies on manual review or the `/simplify` skil
 
 ## Phase 5: Push and create PR
 
-1. Push:
+1. Push with the explicit-destination refspec (see CRITICAL — bare-branch form
+   can push to `main` when the local branch's upstream is `origin/main`):
 
    ```bash
-   git push -u origin <branch>
+   git push -u origin HEAD:refs/heads/<branch>
    ```
 
 2. Create PR with HEREDOC body:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,11 @@
 #
 # See issue #134 for background on why we use local hooks.
 
+# Make `pre-commit install` set up the pre-push hook too. Without this, the
+# pre-push hook would silently not run for contributors who only ran the bare
+# `pre-commit install` from the README. See block-push-to-main below.
+default_install_hook_types: [pre-commit, pre-push]
+
 repos:
   - repo: local
     hooks:
@@ -53,5 +58,19 @@ repos:
         name: pytest
         entry: uv run poe test
         language: system
+        pass_filenames: false
+        always_run: true
+
+      # Refuse pushes that would land non-main commits on the `main` ref.
+      # See CLAUDE.md "Known Pitfalls" — git's tracked-upstream resolution can
+      # silently route `git push -u origin <branch>` to main when the local
+      # branch was created from origin/main. Mechanical guardrail, ported
+      # from katana-openapi-client (#434) after a real release-pipeline
+      # incident there.
+      - id: block-push-to-main
+        name: block direct push to main from a non-main branch
+        entry: scripts/pre-push-guard.sh
+        language: system
+        stages: [pre-push]
         pass_filenames: false
         always_run: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,9 +6,14 @@ Guidance for Claude Code working with this repository.
 
 ```bash
 uv sync --all-extras         # Install dependencies
-uv run pre-commit install    # Setup hooks
+uv run pre-commit install    # Setup hooks (incl. pre-push guard)
 cp .env.example .env         # Add STATUSPRO_API_KEY
 ```
+
+> **Worktree note**: pre-commit hooks aren't shared across git worktrees. Fresh
+> worktrees only have whatever hooks were installed at clone time — re-run
+> `uv run pre-commit install` after creating a new worktree, otherwise the pre-push
+> guard won't fire.
 
 ## Essential Commands
 
@@ -92,6 +97,13 @@ Common mistakes to avoid:
 - **None-to-UNSET conversion** — When building attrs API request models from optional
   fields, use `to_unset(value)` from `statuspro_public_api_client.domain.converters`
   instead of `value if value is not None else UNSET`.
+- **Push-refspec trap** — `git checkout -b <name> origin/main` sets the new branch's
+  upstream to `origin/main`. A subsequent `git push -u origin <name>` then resolves to
+  the tracked upstream and pushes straight to **`main`**, bypassing PR review. Always
+  use the explicit-destination form: `git push -u origin HEAD:refs/heads/<name>`. The
+  pre-push guard at `scripts/pre-push-guard.sh` catches this mistake — but only fires if
+  `pre-commit install` has run in the current worktree (hooks aren't shared across
+  worktrees). Bypassing the guard with `--no-verify` is forbidden by project policy.
 
 ## Using the LSP tool
 

--- a/scripts/pre-push-guard.sh
+++ b/scripts/pre-push-guard.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Pre-push guard: refuse pushes that land non-main commits on the `main` ref.
+#
+# Why this exists: when a feature branch is created via
+#   git checkout -b <name> origin/main
+# git sets the new local branch's upstream to origin/main. A subsequent
+#   git push -u origin <name>
+# resolves <name> to the tracked upstream and pushes straight to main. This
+# pattern caused a real release-pipeline incident in our sister repo
+# (katana-openapi-client commit 30f3fd86) before the guard was added there.
+#
+# pre-commit invokes this with the remote name as $1, the URL as $2, and
+# `<local-ref> <local-sha> <remote-ref> <remote-sha>` lines on stdin.
+#
+# Bypass via --no-verify is forbidden by project policy (see CLAUDE.md). The
+# right form for first-time feature-branch pushes is:
+#   git push -u origin HEAD:refs/heads/<branch-name>
+
+set -euo pipefail
+
+EXIT_CODE=0
+
+while read -r local_ref _local_sha remote_ref _remote_sha; do
+    # Skip deletions (local_ref is empty when a remote ref is being deleted).
+    [ -z "$local_ref" ] && continue
+
+    # Only guard pushes that target main.
+    case "$remote_ref" in
+        refs/heads/main) ;;
+        *) continue ;;
+    esac
+
+    # The local ref-name pushed to main must itself be `main`. Refuse anything else.
+    case "$local_ref" in
+        refs/heads/main)
+            # ok — main → main is the legitimate path for admins/release automation
+            ;;
+        refs/heads/*)
+            # Branch other than main → main: the common upstream-tracking mistake.
+            # Suggest the canonical safe form with the actual branch name.
+            local_short="${local_ref#refs/heads/}"
+            cat >&2 <<EOF
+ERROR: refusing to push '$local_short' to remote 'main'.
+
+This is almost always git's tracked-upstream resolution biting you — the
+local branch was probably created via 'git checkout -b $local_short origin/main',
+so its upstream is origin/main and a bare 'git push -u origin $local_short' targets main.
+
+The fix: use an explicit destination ref so the remote branch name matches:
+
+    git push -u origin HEAD:refs/heads/$local_short
+
+If you genuinely need to push to main from a non-main branch (rare), do it
+through a PR. Bypassing this hook with --no-verify is forbidden by project policy
+— see CLAUDE.md 'Known Pitfalls'.
+EOF
+            EXIT_CODE=1
+            ;;
+        *)
+            # Detached HEAD push, tag-to-main push, or some other unusual ref shape.
+            # Don't try to construct a branch name from a ref we don't understand —
+            # print a generic safe form instead.
+            cat >&2 <<EOF
+ERROR: refusing to push '$local_ref' to remote 'main'.
+
+The local ref isn't a normal branch (got: $local_ref). Pushes to main from
+anything other than the local 'main' branch are blocked.
+
+If you intended to push your current work to a new feature branch:
+
+    git push -u origin HEAD:refs/heads/<branch-name>
+
+Then open a PR. Bypassing this hook with --no-verify is forbidden by project
+policy — see CLAUDE.md 'Known Pitfalls'.
+EOF
+            EXIT_CODE=1
+            ;;
+    esac
+done
+
+exit "$EXIT_CODE"

--- a/statuspro_mcp_server/src/statuspro_mcp/resources/help.py
+++ b/statuspro_mcp_server/src/statuspro_mcp/resources/help.py
@@ -47,6 +47,20 @@ update_order_status(
 update_order_status(…, confirm=True)  # apply
 ```
 
+## Input handling
+
+List-typed parameters (`tags`, `tags_any`, `financial_status`,
+`fulfillment_status`, `order_ids`, `order_numbers`) accept three input
+shapes — pass whichever is most natural for the call:
+
+- A real list: `["20486", "20487"]`
+- A JSON-stringified array: `'["20486", "20487"]'`
+- A comma-separated string: `"20486,20487"`
+
+The CSV and JSON-string forms are normalized to a list before validation.
+Empty / whitespace-only strings yield `[]`. Anything else (e.g. a bare
+integer for a `list[int]` field) raises a normal pydantic type error.
+
 ## Rate limits
 
 StatusPro documents rate limits per-endpoint in its OpenAPI description (not

--- a/statuspro_mcp_server/src/statuspro_mcp/tools/list_coercion.py
+++ b/statuspro_mcp_server/src/statuspro_mcp/tools/list_coercion.py
@@ -57,17 +57,19 @@ def coerce_str_list_input(value: Any) -> Any:
         return []
 
     # JSON-stringified array: '[...]' — trust it if it parses to a list.
+    # ``json.JSONDecodeError`` is a subclass of ``ValueError``; catching the
+    # parent covers both.
     if s.startswith("["):
         try:
             parsed = json.loads(s)
-        except (json.JSONDecodeError, ValueError):
+        except ValueError:
             pass
         else:
             if isinstance(parsed, list):
                 return parsed
 
     # Fall back to CSV: split, strip, drop empty fragments.
-    return [item.strip() for item in s.split(",") if item.strip()]
+    return [stripped for item in s.split(",") if (stripped := item.strip())]
 
 
 # Type aliases — collapse the per-field

--- a/statuspro_mcp_server/src/statuspro_mcp/tools/list_coercion.py
+++ b/statuspro_mcp_server/src/statuspro_mcp/tools/list_coercion.py
@@ -1,0 +1,85 @@
+"""Coerce LLM-mistyped list inputs back into Python lists.
+
+LLMs occasionally send list-typed tool arguments as a single string instead
+of a JSON array. Two shapes are observed in the wild:
+
+1. **Comma-separated values**: ``"20486,20487,20488"``
+2. **JSON-stringified array**: ``'["20486", "20487"]'``
+
+When this happens, pydantic raises ``Input should be a valid list
+[type=list_type, input_type=str]``, the tool call fails, and the user has
+to retry. The recovery is mechanical and lossless — split on commas (or
+parse as JSON), strip whitespace, hand pydantic a real list. So we do it.
+
+Usage on an LLM-facing tool parameter — prefer the prebuilt aliases::
+
+    from pydantic import Field
+    from statuspro_mcp.tools.list_coercion import CoercedStrListOpt
+
+    async def list_orders(
+        ...,
+        tags: Annotated[CoercedStrListOpt, Field(description="...")] = None,
+    ) -> ...:
+
+Required (non-Optional) variants and the heterogeneous ``str | int`` shape
+have aliases too — see below. Use the raw ``coerce_str_list_input``
+validator directly only for one-off types that don't fit the aliases.
+
+Apply only to **LLM-facing** tool parameters and request-model fields.
+Internal/response-side list fields don't need it — pydantic-on-pydantic
+round-trips already use real lists.
+
+Ported from katana-openapi-client (#428).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Annotated, Any
+
+from pydantic import BeforeValidator
+
+
+def coerce_str_list_input(value: Any) -> Any:
+    """Best-effort recovery of LLM-mistyped list arguments.
+
+    - List input → returned unchanged.
+    - String input → parsed as JSON if it looks like an array, otherwise
+      split on commas with whitespace stripped. Empty strings yield ``[]``.
+    - Anything else → returned unchanged so pydantic raises its normal
+      type error (don't mask genuinely malformed input).
+    """
+    if not isinstance(value, str):
+        return value
+
+    s = value.strip()
+    if not s:
+        return []
+
+    # JSON-stringified array: '[...]' — trust it if it parses to a list.
+    if s.startswith("["):
+        try:
+            parsed = json.loads(s)
+        except (json.JSONDecodeError, ValueError):
+            pass
+        else:
+            if isinstance(parsed, list):
+                return parsed
+
+    # Fall back to CSV: split, strip, drop empty fragments.
+    return [item.strip() for item in s.split(",") if item.strip()]
+
+
+# Type aliases — collapse the per-field
+# ``Annotated[list[X] | None, BeforeValidator(coerce_str_list_input)]`` boilerplate
+# into a single readable token at the call site. ``Opt`` suffix marks the
+# Optional/None-default variant; bare names are required (non-Optional).
+
+CoercedStrList = Annotated[list[str], BeforeValidator(coerce_str_list_input)]
+CoercedStrListOpt = Annotated[list[str] | None, BeforeValidator(coerce_str_list_input)]
+CoercedIntList = Annotated[list[int], BeforeValidator(coerce_str_list_input)]
+CoercedIntListOpt = Annotated[list[int] | None, BeforeValidator(coerce_str_list_input)]
+CoercedStrIntList = Annotated[list[str | int], BeforeValidator(coerce_str_list_input)]
+CoercedStrIntListOpt = Annotated[
+    list[str | int] | None, BeforeValidator(coerce_str_list_input)
+]

--- a/statuspro_mcp_server/src/statuspro_mcp/tools/orders.py
+++ b/statuspro_mcp_server/src/statuspro_mcp/tools/orders.py
@@ -38,6 +38,11 @@ from mcp.types import ToolAnnotations
 from pydantic import Field
 
 from statuspro_mcp.services import get_services
+from statuspro_mcp.tools.list_coercion import (
+    CoercedIntList,
+    CoercedStrList,
+    CoercedStrListOpt,
+)
 from statuspro_mcp.tools.prefab_ui import (
     build_bulk_status_change_preview_ui,
     build_comment_preview_ui,
@@ -377,13 +382,19 @@ def register_tools(mcp: FastMCP) -> None:
             str | None, Field(description="Filter to one status code")
         ] = None,
         tags: Annotated[
-            list[str] | None, Field(description="Must match all tags")
+            CoercedStrListOpt, Field(description="Must match all tags")
         ] = None,
         tags_any: Annotated[
-            list[str] | None, Field(description="Match any of these tags")
+            CoercedStrListOpt, Field(description="Match any of these tags")
         ] = None,
-        financial_status: list[str] | None = None,
-        fulfillment_status: list[str] | None = None,
+        financial_status: Annotated[
+            CoercedStrListOpt,
+            Field(description="Filter by financial status (e.g. paid, pending)"),
+        ] = None,
+        fulfillment_status: Annotated[
+            CoercedStrListOpt,
+            Field(description="Filter by fulfillment status (e.g. fulfilled, partial)"),
+        ] = None,
         exclude_cancelled: Annotated[
             bool | None, Field(description="Exclude cancelled orders")
         ] = None,
@@ -584,7 +595,7 @@ def register_tools(mcp: FastMCP) -> None:
     async def get_orders_batch(
         context: Context,
         order_ids: Annotated[
-            list[int],
+            CoercedIntList,
             Field(
                 description="Order ids to fetch (1-50 items).",
                 min_length=1,
@@ -635,7 +646,7 @@ def register_tools(mcp: FastMCP) -> None:
     async def lookup_orders_batch(
         context: Context,
         order_numbers: Annotated[
-            list[str],
+            CoercedStrList,
             Field(
                 description=(
                     "Order numbers to resolve (1-50 items). Both '20486' "
@@ -1029,7 +1040,7 @@ def register_tools(mcp: FastMCP) -> None:
     async def bulk_update_order_status(
         context: Context,
         order_ids: Annotated[
-            list[int],
+            CoercedIntList,
             Field(description="Order ids (1-50 items)", min_length=1, max_length=50),
         ],
         status_code: str,

--- a/statuspro_mcp_server/src/statuspro_mcp/tools/prefab_ui.py
+++ b/statuspro_mcp_server/src/statuspro_mcp/tools/prefab_ui.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from typing import Any, Literal
 
+from prefab_ui.actions import ShowToast
 from prefab_ui.actions.mcp import CallTool, SendMessage
 from prefab_ui.app import PrefabApp
 from prefab_ui.components import (
@@ -377,7 +378,7 @@ def build_status_change_preview_ui(
             Button(
                 label="Cancel",
                 variant="outline",
-                on_click=SendMessage("Cancel the status change"),
+                on_click=ShowToast(message="Status change cancelled", variant="info"),
             )
     return app
 
@@ -436,7 +437,7 @@ def build_comment_preview_ui(preview: dict[str, Any]) -> PrefabApp:
             Button(
                 label="Cancel",
                 variant="outline",
-                on_click=SendMessage("Cancel the comment"),
+                on_click=ShowToast(message="Comment cancelled", variant="info"),
             )
     return app
 
@@ -491,7 +492,7 @@ def build_due_date_change_preview_ui(preview: dict[str, Any]) -> PrefabApp:
             Button(
                 label="Cancel",
                 variant="outline",
-                on_click=SendMessage("Cancel the due date change"),
+                on_click=ShowToast(message="Due date change cancelled", variant="info"),
             )
     return app
 
@@ -566,7 +567,7 @@ def build_bulk_status_change_preview_ui(preview: dict[str, Any]) -> PrefabApp:
             Button(
                 label="Cancel",
                 variant="outline",
-                on_click=SendMessage("Cancel the bulk update"),
+                on_click=ShowToast(message="Bulk update cancelled", variant="info"),
             )
     return app
 

--- a/statuspro_mcp_server/tests/test_observability_decorators.py
+++ b/statuspro_mcp_server/tests/test_observability_decorators.py
@@ -223,57 +223,65 @@ async def test_observe_service_preserves_function_metadata(setup_test_logging):
 
 @pytest.mark.asyncio
 async def test_observe_tool_timing_accuracy(setup_test_logging):
-    """Test that @observe_tool decorator measures time accurately."""
-    import asyncio
+    """``@observe_tool`` must compute ``duration_ms = (end - start) * 1000``.
+
+    Mocks ``time.perf_counter`` so timing is deterministic — no real sleep,
+    no asyncio scheduler variance, no CI-runner-load flakiness. The decorator
+    calls ``perf_counter()`` twice (start + end); we hand back ``[200.0,
+    200.1]`` so the computed duration is exactly 100ms.
+    """
 
     @observe_tool
     async def slow_tool(param: str) -> str:
-        """Tool that takes time to execute."""
-        await asyncio.sleep(0.1)  # Sleep for 100ms
         return param
 
-    # Mock logger to capture calls
-    with patch("statuspro_mcp.logging.get_logger") as mock_get_logger:
+    with (
+        patch("statuspro_mcp.logging.get_logger") as mock_get_logger,
+        patch(
+            "statuspro_mcp.logging.time.perf_counter",
+            side_effect=[200.0, 200.1],
+        ),
+    ):
         mock_logger = MagicMock()
         mock_get_logger.return_value = mock_logger
 
-        # Execute tool
         await slow_tool(param="test")
 
-        # Check that duration is roughly 100ms or more
         completed_call = mock_logger.info.call_args_list[1]
         duration_ms = completed_call[1]["duration_ms"]
-        assert duration_ms >= 100  # Should be at least 100ms
-        assert duration_ms < 200  # But not too much more (with some tolerance)
+        assert duration_ms == 100.0
 
 
 @pytest.mark.asyncio
 async def test_observe_service_timing_accuracy(setup_test_logging):
-    """Test that @observe_service decorator measures time accurately."""
-    import asyncio
+    """``@observe_service`` must compute ``duration_ms = (end - start) * 1000``.
+
+    Same approach as ``test_observe_tool_timing_accuracy`` — mock
+    ``time.perf_counter`` for deterministic timing. Hand back ``[100.0,
+    100.05]`` so the computed duration is exactly 50ms.
+    """
 
     class TestService:
         @observe_service("slow_operation")
         async def slow_method(self) -> str:
-            """Method that takes time to execute."""
-            await asyncio.sleep(0.05)  # Sleep for 50ms
             return "done"
 
-    # Mock logger to capture calls
-    with patch("statuspro_mcp.logging.get_logger") as mock_get_logger:
+    with (
+        patch("statuspro_mcp.logging.get_logger") as mock_get_logger,
+        patch(
+            "statuspro_mcp.logging.time.perf_counter",
+            side_effect=[100.0, 100.05],
+        ),
+    ):
         mock_logger = MagicMock()
         mock_get_logger.return_value = mock_logger
 
-        # Execute service method
         service = TestService()
         await service.slow_method()
 
-        # Check that duration is roughly 50ms or more. Upper bound is generous
-        # because shared CI runners occasionally add 50-100ms of scheduling jitter.
         completed_call = mock_logger.debug.call_args_list[1]
         duration_ms = completed_call[1]["duration_ms"]
-        assert duration_ms >= 50  # Should be at least 50ms (asyncio.sleep guarantee)
-        assert duration_ms < 500  # Room for CI jitter; still proves timing is measured
+        assert duration_ms == 50.0
 
 
 @pytest.mark.asyncio

--- a/statuspro_mcp_server/tests/tools/test_list_coercion.py
+++ b/statuspro_mcp_server/tests/tools/test_list_coercion.py
@@ -1,0 +1,152 @@
+"""Tests for the list-coercion BeforeValidator.
+
+LLM-emitted call shapes that motivated this — both observed in the wild
+during katana-openapi-client's #428 incident:
+
+  CSV form:           ``order_ids='20486,20487,20488'``
+  JSON-stringified:   ``order_ids='[20486, 20487, 20488]'``
+
+Pydantic raises ``Input should be a valid list [type=list_type,
+input_type=str]`` for both, the tool call aborts, and the user has to
+retry. With the BeforeValidator wired in via the ``Coerced*`` aliases,
+both shapes recover transparently without losing data.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import BaseModel, Field, ValidationError
+from statuspro_mcp.tools.list_coercion import (
+    CoercedIntListOpt,
+    CoercedStrIntList,
+    CoercedStrListOpt,
+)
+
+
+class _RequestStub(BaseModel):
+    """Mimics the shape of an LLM-facing tool parameter / request-model field."""
+
+    tags: CoercedStrListOpt = Field(default=None)
+    order_ids: CoercedIntListOpt = Field(default=None)
+    # Stub of a ``CoercedStrIntList`` (mixed str|int list, required-typed)
+    # so the mixed-type tests below can exercise the alias. Uses
+    # ``default_factory`` so ``_build()`` can omit it.
+    required_mixed: CoercedStrIntList = Field(default_factory=list)
+
+
+def _build(**kwargs: object) -> _RequestStub:
+    """Use ``model_validate`` so we can pass string-typed inputs through the
+    BeforeValidator without arguing with pyright about the field annotation.
+    Mirrors how MCP/fastmcp actually constructs the request from the LLM-supplied
+    JSON dict."""
+    return _RequestStub.model_validate(kwargs)
+
+
+def test_list_input_passes_through_unchanged():
+    assert _build(tags=["A", "B", "C"]).tags == ["A", "B", "C"]
+
+
+def test_csv_string_splits_into_list():
+    assert _build(tags="rush,priority,vip").tags == ["rush", "priority", "vip"]
+
+
+def test_csv_string_strips_whitespace_and_drops_empty_fragments():
+    assert _build(tags=" rush , , priority ,").tags == ["rush", "priority"]
+
+
+def test_json_stringified_array_is_parsed():
+    assert _build(tags='["rush", "priority"]').tags == ["rush", "priority"]
+
+
+def test_json_stringified_array_with_ints_coerces_for_int_field():
+    assert _build(order_ids="[20486, 20487, 20488]").order_ids == [
+        20486,
+        20487,
+        20488,
+    ]
+
+
+def test_csv_string_of_ints_coerces_via_pydantic():
+    # CSV path returns strings; pydantic's list[int] coerces each element.
+    assert _build(order_ids="20486,20487,20488").order_ids == [20486, 20487, 20488]
+
+
+def test_empty_string_yields_empty_list():
+    assert _build(tags="").tags == []
+
+
+def test_whitespace_only_string_yields_empty_list():
+    assert _build(tags="   ").tags == []
+
+
+def test_none_passes_through():
+    assert _build(tags=None).tags is None
+
+
+def test_omitted_field_keeps_default():
+    assert _build().tags is None
+
+
+def test_malformed_json_falls_back_to_csv_split():
+    # Unclosed bracket — JSON parse fails, CSV split runs on the whole string.
+    assert _build(tags="[rush,priority").tags == ["[rush", "priority"]
+
+
+def test_non_list_json_falls_back_to_csv_split():
+    # JSON parses but isn't a list — keep the string-y CSV path.
+    assert _build(tags='{"key":"value"}').tags == ['{"key":"value"}']
+
+
+def test_non_string_non_list_input_raises_normal_pydantic_error():
+    # Don't mask genuinely wrong types — pydantic's diagnostic still fires.
+    with pytest.raises(ValidationError):
+        _build(tags=42)
+
+
+def test_int_input_for_int_list_raises_normal_pydantic_error():
+    # Same — a bare int for list[int] should still be a real error.
+    with pytest.raises(ValidationError):
+        _build(order_ids=42)
+
+
+def test_single_value_string_no_comma_yields_one_item_list():
+    # ``tags="rush"`` is the LLM's most innocent form of the bug.
+    assert _build(tags="rush").tags == ["rush"]
+
+
+def test_mixed_type_list_passthrough():
+    # The CoercedStrIntList alias accepts mixed input types — pydantic
+    # validates each element against ``str | int``.
+    req = _build(required_mixed=["rush", 12345, "vip"])
+    assert req.required_mixed == ["rush", 12345, "vip"]
+
+
+def test_csv_with_numeric_items_for_str_int_list_keeps_strings():
+    # CSV path returns strings; pydantic's ``str | int`` union accepts both.
+    req = _build(required_mixed="rush,12345")
+    assert req.required_mixed == ["rush", "12345"]
+
+
+def test_empty_string_plus_min_length_one_raises_min_length_error():
+    """Empty string coerces to ``[]``, so a field with ``min_length=1``
+    raises a ``too_short`` error rather than the original ``list_type``
+    error. Documents the resulting UX so a future contributor doesn't
+    accidentally regress to the old shape.
+    """
+
+    class _Req(BaseModel):
+        tags: CoercedStrListOpt = Field(default=None, min_length=1)
+
+    with pytest.raises(ValidationError) as exc_info:
+        _Req.model_validate({"tags": ""})
+
+    errors = exc_info.value.errors()
+    assert errors[0]["type"] == "too_short"
+
+
+def test_non_numeric_string_for_int_list_raises_pydantic_error():
+    # CSV split yields ``["abc"]``; pydantic can't coerce that to int.
+    with pytest.raises(ValidationError) as exc_info:
+        _build(order_ids="abc")
+    errors = exc_info.value.errors()
+    assert errors[0]["type"] == "int_parsing"


### PR DESCRIPTION
## Summary

Catches statuspro-openapi-client up to recent developments in sister repo katana-openapi-client. Six commits, organized by theme:

**Safety / process**
- `dc3285e` — pre-push guard hook blocking pushes that would land non-`main` commits on the `main` ref. Ports katana #434 (which followed a real release-pipeline incident: `git push -u origin <branch>` resolved through the local branch's `origin/main` upstream and shipped straight to main).
- `481354b` — `/open-pr` skill mandates the safe refspec form (`git push -u origin HEAD:refs/heads/<branch>`); CLAUDE.md gains a worktree note + push-refspec entry in Known Pitfalls. Ports katana #441.

**Test reliability**
- `5a6eb4f` — observability timing tests now mock `time.perf_counter` for deterministic duration assertions (`==` exact). Eliminates the `< 200ms` upper-bound flake pattern that bit katana CI on Python 3.14 (235.7ms < 100ms). Test runtime drops from ~150ms to ~1ms. Ports katana #450 / #446 fix-up.

**MCP UX**
- `a7fe3cc` — four Cancel buttons in Prefab preview UIs swap `SendMessage("Cancel the X")` → `ShowToast(...)`. No more synthetic user messages and LLM round-trips for a do-nothing action. Ports katana #440.
- `3418251` — new `list_coercion` module recovers LLM-mistyped list inputs (CSV strings, JSON-stringified arrays) before pydantic. 19 unit tests; applied to seven LLM-facing list params (`tags`, `tags_any`, `financial_status`, `fulfillment_status`, `order_ids`×2, `order_numbers`). Ports katana #428 + the underlying #30f3fd86 fix.
- `15f4a7c` — `/simplify` pass on the freshly-landed coercion module: drop redundant `(JSONDecodeError, ValueError)` tuple (subclass relationship), single-strip via walrus.

**Skipped (with rationale)**
- katana #448 (deep-link embedding): needs StatusPro web-app URL scheme; not safely guessable from the codebase.
- katana #446 (preview-fetches-backing-data + BLOCK marker): statuspro's preview path uses bare dicts, not Prefab branches with empty-render risk.
- katana #420/#421 (spec drift audit tooling, ~1500 LOC): ROI question for statuspro's 7-endpoint surface vs. katana's 110 paths. Worth a smaller adaptation as a separate decision.
- katana #456, #365, #406, #449 (typed-cache, EntitySpec, MO triage): katana-specific scale features that don't apply.

## Test plan

- [ ] `uv run poe check` — full validation (already green locally: 295 passed, 1 skipped)
- [ ] Verify pre-push guard rejects `refs/heads/<branch> → refs/heads/main`:
  ```
  echo "refs/heads/test abc refs/heads/main def" | scripts/pre-push-guard.sh origin <url>
  ```
  expected: exit 1, helpful error suggesting `HEAD:refs/heads/test` form
- [ ] Verify guard allows `refs/heads/main → refs/heads/main` and `refs/heads/feat → refs/heads/feat`: exit 0
- [ ] Run only the new list-coercion tests: `uv run pytest statuspro_mcp_server/tests/tools/test_list_coercion.py -v` — 19 passed
- [ ] Confirm timing tests are deterministic: `uv run pytest statuspro_mcp_server/tests/test_observability_decorators.py::test_observe_tool_timing_accuracy statuspro_mcp_server/tests/test_observability_decorators.py::test_observe_service_timing_accuracy -v` — runtime <100ms total

🤖 Generated with [Claude Code](https://claude.com/claude-code)