### PR TITLE
refactor(mcp): tighten tool param types + fix latent type errors pyright caught

### DIFF
--- a/statuspro_mcp_server/src/statuspro_mcp/tools/orders.py
+++ b/statuspro_mcp_server/src/statuspro_mcp/tools/orders.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections.abc import Awaitable
 from typing import Annotated, Any
 
 from fastmcp import Context, FastMCP
@@ -82,6 +83,7 @@ from statuspro_public_api_client.api.orders import (
     set_order_due_date,
     update_order_status as update_order_status_api,
 )
+from statuspro_public_api_client.domain.converters import to_unset
 from statuspro_public_api_client.models.add_order_comment_request import (
     AddOrderCommentRequest,
 )
@@ -146,7 +148,7 @@ _BATCH_CONCURRENCY_LIMIT = 10
 
 
 async def _bounded_gather[T](
-    coros: list[Any], *, limit: int = _BATCH_CONCURRENCY_LIMIT
+    coros: list[Awaitable[T]], *, limit: int = _BATCH_CONCURRENCY_LIMIT
 ) -> list[T | Exception]:
     """Run ``coros`` with bounded concurrency; mirrors ``asyncio.gather`` shape.
 
@@ -158,7 +160,7 @@ async def _bounded_gather[T](
     """
     sem = asyncio.Semaphore(limit)
 
-    async def _run(coro: Any) -> Any:
+    async def _run(coro: Awaitable[T]) -> T | Exception:
         async with sem:
             try:
                 return await coro
@@ -759,7 +761,7 @@ def register_tools(mcp: FastMCP) -> None:
         # endpoint and turn one rate-limit hit into 20 retries in lockstep.
         sem = asyncio.Semaphore(_BATCH_CONCURRENCY_LIMIT)
 
-        async def bounded[T](coro: Any) -> T:
+        async def bounded[T](coro: Awaitable[T]) -> T:
             async with sem:
                 return await coro
 
@@ -927,7 +929,7 @@ def register_tools(mcp: FastMCP) -> None:
 
         body = UpdateOrderStatusRequest(
             status_code=status_code,
-            comment=comment,
+            comment=to_unset(comment),
             public=public,
             email_customer=email_customer,
             email_additional=email_additional,
@@ -1079,7 +1081,7 @@ def register_tools(mcp: FastMCP) -> None:
         body = BulkStatusUpdateRequest(
             order_ids=order_ids,
             status_code=status_code,
-            comment=comment,
+            comment=to_unset(comment),
             public=public,
             email_customer=email_customer,
             email_additional=email_additional,

--- a/statuspro_mcp_server/src/statuspro_mcp/tools/orders.py
+++ b/statuspro_mcp_server/src/statuspro_mcp/tools/orders.py
@@ -44,6 +44,7 @@ from statuspro_mcp.tools.list_coercion import (
     CoercedStrList,
     CoercedStrListOpt,
 )
+from statuspro_mcp.tools.param_types import ConfirmFlag, OrderIdParam
 from statuspro_mcp.tools.prefab_ui import (
     build_bulk_status_change_preview_ui,
     build_comment_preview_ui,
@@ -563,7 +564,7 @@ def register_tools(mcp: FastMCP) -> None:
     )
     async def get_order(
         context: Context,
-        order_id: Annotated[int, Field(description="StatusPro order id")],
+        order_id: OrderIdParam,
         history_limit: Annotated[
             int,
             Field(
@@ -812,7 +813,7 @@ def register_tools(mcp: FastMCP) -> None:
     )
     async def get_order_history(
         context: Context,
-        order_id: Annotated[int, Field(description="StatusPro order id")],
+        order_id: OrderIdParam,
         page: Annotated[
             int,
             Field(description="1-based page number.", ge=1),
@@ -851,7 +852,7 @@ def register_tools(mcp: FastMCP) -> None:
     )
     async def update_order_status(
         context: Context,
-        order_id: int,
+        order_id: OrderIdParam,
         status_code: Annotated[
             str, Field(description="8-char status code, e.g. 'st000002'")
         ],
@@ -867,9 +868,7 @@ def register_tools(mcp: FastMCP) -> None:
         email_additional: Annotated[
             bool, Field(description="Send additional notification emails")
         ] = True,
-        confirm: Annotated[
-            bool, Field(description="Must be true to apply the change")
-        ] = False,
+        confirm: ConfirmFlag = False,
     ) -> ToolResult:
         services = get_services(context)
 
@@ -953,10 +952,10 @@ def register_tools(mcp: FastMCP) -> None:
     )
     async def add_order_comment(
         context: Context,
-        order_id: int,
+        order_id: OrderIdParam,
         comment: Annotated[str, Field(description="Comment body")],
         public: Annotated[bool, Field(description="Visible to the customer")] = False,
-        confirm: bool = False,
+        confirm: ConfirmFlag = False,
     ) -> ToolResult:
         services = get_services(context)
 
@@ -991,12 +990,12 @@ def register_tools(mcp: FastMCP) -> None:
     )
     async def update_order_due_date(
         context: Context,
-        order_id: int,
+        order_id: OrderIdParam,
         due_date: Annotated[str, Field(description="ISO 8601 date, e.g. '2026-03-15'")],
         due_date_to: Annotated[
             str | None, Field(description="Optional end of the range")
         ] = None,
-        confirm: bool = False,
+        confirm: ConfirmFlag = False,
     ) -> ToolResult:
         services = get_services(context)
 
@@ -1050,7 +1049,7 @@ def register_tools(mcp: FastMCP) -> None:
         public: bool = False,
         email_customer: bool = True,
         email_additional: bool = True,
-        confirm: bool = False,
+        confirm: ConfirmFlag = False,
     ) -> ToolResult:
         services = get_services(context)
 

--- a/statuspro_mcp_server/src/statuspro_mcp/tools/param_types.py
+++ b/statuspro_mcp_server/src/statuspro_mcp/tools/param_types.py
@@ -1,0 +1,22 @@
+"""Reusable ``Annotated[..., Field(...)]`` aliases for MCP tool parameters.
+
+Tool registrations push ``Field(description=...)`` metadata into the JSON
+schema FastMCP advertises to clients, which gives the LLM inline guidance
+about each argument. When the same parameter (``order_id``, the
+``confirm`` two-step flag) appears across many tools, repeating the full
+``Annotated[...]`` literal at every call site drifts: descriptions go out
+of sync between siblings, the convention is harder to enforce in review,
+and bare ``int`` / ``bool`` slips back in (the documented anti-pattern).
+
+Mirrors the pattern in ``list_coercion.py``: collapse the per-field
+boilerplate into a single readable token at the call site.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from pydantic import Field
+
+OrderIdParam = Annotated[int, Field(description="StatusPro order id")]
+ConfirmFlag = Annotated[bool, Field(description="Set to true to apply the change")]

--- a/statuspro_mcp_server/src/statuspro_mcp/tools/schemas.py
+++ b/statuspro_mcp_server/src/statuspro_mcp/tools/schemas.py
@@ -83,7 +83,7 @@ class BatchOrderResult(BaseModel):
     """
 
     order_id: int | None = Field(
-        None,
+        default=None,
         description="The order id if known. May be None for lookup-by-number where no id was resolved.",
     )
     requested: str = Field(
@@ -95,7 +95,7 @@ class BatchOrderResult(BaseModel):
     )
     order: OrderSummary | None = None
     error: str | None = Field(
-        None,
+        default=None,
         description="Set when the lookup failed; describes why (not_found, ambiguous, etc.).",
     )
 

--- a/statuspro_mcp_server/src/statuspro_mcp/tools/statuses.py
+++ b/statuspro_mcp_server/src/statuspro_mcp/tools/statuses.py
@@ -15,6 +15,7 @@ from fastmcp import Context, FastMCP
 from fastmcp.tools import ToolResult
 
 from statuspro_mcp.services import get_services
+from statuspro_mcp.tools.param_types import OrderIdParam
 from statuspro_mcp.tools.prefab_ui import build_viable_statuses_ui
 from statuspro_mcp.tools.schemas import StatusEntry, ViableStatusesResponse
 from statuspro_mcp.tools.tool_result_utils import UI_META, make_tool_result
@@ -50,7 +51,10 @@ def register_tools(mcp: FastMCP) -> None:
         ),
         meta=UI_META,
     )
-    async def get_viable_statuses(context: Context, order_id: int) -> ToolResult:
+    async def get_viable_statuses(
+        context: Context,
+        order_id: OrderIdParam,
+    ) -> ToolResult:
         services = get_services(context)
         statuses = await services.client.statuses.viable_for(order_id)
         entries = [_to_entry(s) for s in statuses]


### PR DESCRIPTION
## Summary

Two-commit PR cleaning up MCP tool parameter typing in `statuspro_mcp_server/`. Surfaced during a `/techdebt-scan` followed by `code-modernizer` invocation, where pyright (LSP) caught real type errors that `ty` (validation) silently misses today (see #56).

### Commit 1 — `fix(mcp): correct latent type errors pyright surfaced`

Three small, behavior-preserving type bugs:

- `tools/schemas.py` — `BatchOrderResult.order_id` and `.error` switched from positional `Field(None, …)` (pyright reads as required) to `Field(default=None, …)`. Fixes "Argument missing for parameter `order_id`" at three constructor sites in `orders.py`.
- `tools/orders.py` — `UpdateOrderStatusRequest(comment=…)` and `BulkStatusUpdateRequest(comment=…)` were passing `str | None` from the tool param into attrs fields typed `str | Unset`. Wrapped with `to_unset(comment)` per CLAUDE.md's None → UNSET convention.
- `tools/orders.py` — `_bounded_gather[T]` and inner `bounded[T]` declared a TypeVar that appeared only in the return type. Typed inputs as `list[Awaitable[T]]` / `Awaitable[T]` so T binds at call sites.

### Commit 2 — `refactor(mcp): extract OrderIdParam and ConfirmFlag tool param aliases`

Tool param annotations had drifted: bare `int` / `bool` types on some mutation tools, `Annotated[int, Field(description=…)]` wrappers on others, and one outlier `confirm` description. New `tools/param_types.py` mirrors the `tools/list_coercion.py` convention of collapsing repeated `Annotated[…, Field(…)]` boilerplate into a single alias.

- `OrderIdParam` — used by 6 tools (`get_order`, `get_order_history`, `update_order_status`, `add_order_comment`, `update_order_due_date`, `get_viable_statuses`)
- `ConfirmFlag` — used by 4 mutation tools

### Why

Both classes of bug were latent — they'd been incorrect for as long as the code's been there, and `ty check --exclude statuspro_mcp_server/` never reported them. Concrete data point added to #56 ([comment](https://github.com/dougborg/statuspro-openapi-client/issues/56#issuecomment-4392821510)).

## Test plan

- [x] `uv run poe check` — ruff format/check, prettier, ty, yamllint, pytest 295 passed
- [x] No behavior change — pure type-correctness + alias extraction
- [x] `to_unset(None)` returns `UNSET`, `to_unset("text")` returns `"text"` (per `domain/converters.py`)
- [x] FastMCP processes `Annotated[…, Field(…)]` at registration time only (cached); no per-call overhead from the alias indirection

🤖 Generated with [Claude Code](https://claude.com/claude-code)