### PR TITLE
feat(mcp): preview-card confirm rail + fix ForEach history templating

### DIFF
--- a/statuspro_mcp_server/src/statuspro_mcp/tools/prefab_ui.py
+++ b/statuspro_mcp_server/src/statuspro_mcp/tools/prefab_ui.py
@@ -24,11 +24,14 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from typing import Any, Literal
 
-from prefab_ui.actions import ShowToast
-from prefab_ui.actions.mcp import CallTool, SendMessage
+from prefab_ui.actions import Action, SetState, ShowToast
+from prefab_ui.actions.mcp import CallTool, SendMessage, UpdateContext
 from prefab_ui.app import PrefabApp
 from prefab_ui.components import (
     H3,
+    Alert,
+    AlertDescription,
+    AlertTitle,
     Badge,
     Button,
     Card,
@@ -45,7 +48,8 @@ from prefab_ui.components import (
     Separator,
     Text,
 )
-from prefab_ui.components.control_flow import ForEach
+from prefab_ui.components.control_flow import Elif, Else, ForEach, If
+from prefab_ui.rx import ERROR, RESULT, Rx
 
 from statuspro_mcp.tools.schemas import StatusChangePreview
 
@@ -109,6 +113,171 @@ def _status_chip(code: str | None, name: str | None, color: str | None) -> None:
     """
     label = name or code or "unknown"
     Badge(label=label, variant=_color_to_variant(color))
+
+
+# Initial state seeded into every preview card. The Confirm/Cancel action
+# chains flip these via SetState; the footer's If/Elif blocks bind to them to
+# morph the button row through Preview → Pending… → Applied / Failed /
+# Cancelled. Seeding them up-front gives the iframe something to bind to
+# before the first click — otherwise the first `Rx("pending")` read would
+# resolve to undefined and the disable guard wouldn't fire.
+_PREVIEW_STATE_INIT: dict[str, Any] = {
+    "pending": False,
+    "cancelled": False,
+    "applied": False,
+    "error": None,
+}
+
+
+def _build_confirm_action(
+    tool: str,
+    arguments: dict[str, Any],
+) -> list[Action]:
+    """Build the Confirm-button click chain for a preview card.
+
+    The chain is ``[SetState(pending, True), CallTool(...)]``. Setting
+    ``pending=True`` synchronously before the call fires is the double-click
+    guard: the button also binds ``disabled=Rx("pending") | Rx("cancelled")``
+    as belt-and-suspenders, but the SetState happens *before* the network
+    call so a second click can never sneak through while the iframe's
+    re-render is in flight.
+
+    ``on_success`` clears ``pending`` and flips ``applied=True`` so the
+    button row morphs in-place to a terminal "Applied" pill — the user gets
+    visible confirmation that their click landed. ``UpdateContext`` pushes
+    the structured response into the agent's model context so the next turn
+    sees the apply result without an extra round-trip.
+
+    ``on_error`` clears ``pending`` and flips ``error`` to the failure
+    reason so the footer can swap to a Retry button + inline error text.
+
+    ``error`` is also cleared synchronously at the start of the chain so a
+    Retry click hides the prior failure Alert immediately — without this,
+    a successful retry would leave the stale Alert visible alongside the
+    Applied pill.
+    """
+    return [
+        SetState("pending", True),
+        SetState("error", None),
+        CallTool(
+            tool=tool,
+            arguments=arguments,
+            on_success=[
+                SetState("pending", False),
+                SetState("applied", True),
+                UpdateContext(content=RESULT),
+            ],
+            on_error=[
+                SetState("pending", False),
+                SetState("error", ERROR),
+                # ShowToast.__init__ types ``message: str`` despite the field
+                # being ``RxStr``; coerce so pyright accepts the Rx reference.
+                ShowToast(message=str(ERROR), variant="error"),
+                UpdateContext(content=f"Apply failed: {ERROR}"),
+            ],
+        ),
+    ]
+
+
+def _build_cancel_action(toast_message: str) -> list[Action]:
+    """Build the Cancel-button click chain.
+
+    Flips ``cancelled=True`` so the footer's Else block morphs to a
+    "Cancelled" pill + disabled Cancel button, and surfaces a toast for
+    immediate visual feedback. The Confirm button binds
+    ``disabled=Rx("pending") | Rx("cancelled")`` so cancelling locks out
+    a subsequent confirm as well.
+    """
+    return [
+        SetState("cancelled", True),
+        ShowToast(message=toast_message, variant="info"),
+    ]
+
+
+def _render_error_block() -> None:
+    """Render the inline apply-failed Alert, bound to iframe ``error`` state.
+
+    Sits inside ``CardContent`` and stays hidden until ``on_error`` flips
+    ``error`` to a truthy string; matches katana's shadcn ``Alert`` primitive
+    so the error surface is visually consistent across sibling MCP servers.
+    """
+    with If("error"):
+        Separator()
+        with Alert(variant="destructive", icon="circle-alert"):
+            AlertTitle(content="Apply failed")
+            AlertDescription(content="{{ error }}")
+
+
+def _render_confirm_footer(
+    *,
+    confirm_label: str,
+    confirm_action: list[Action],
+    cancel_action: list[Action],
+    applied_label: str = "Applied",
+) -> None:
+    """Render the preview-card footer button row with a state machine.
+
+    Five visible states driven by ``pending`` / ``cancelled`` / ``applied`` /
+    ``error`` in iframe state. The If/Elif chain checks them in that order:
+
+    - **Pending…** (highest): action in flight — loader icon, disabled.
+    - **Cancelled**: user opted out — outline pill, disabled. Wins over
+      ``error`` so a Cancel click after an apply failure reliably locks the
+      footer down (otherwise the Retry button would keep showing because
+      ``error`` is still set).
+    - **Applied**: terminal success — success pill, disabled. The agent
+      has the structured result via ``UpdateContext``.
+    - **Error**: apply failed — warning Retry pill. Cancel remains usable
+      and (per its own ``disabled`` binding) ends the flow.
+    - **Preview** (initial, ``Else()``): Confirm + Cancel both enabled.
+
+    Must be called inside a ``CardFooter`` context.
+    """
+    with Row(gap=2):
+        with If("pending"):
+            Button(
+                label="Applying…",
+                variant="default",
+                icon="loader",
+                disabled=True,
+            )
+        with Elif("cancelled"):
+            Button(label="Cancelled", variant="outline", disabled=True)
+        with Elif("applied"):
+            Button(
+                label=applied_label,
+                variant="success",
+                icon="check",
+                disabled=True,
+            )
+        with Elif("error"):
+            Button(
+                label="Retry",
+                variant="warning",
+                icon="rotate-cw",
+                on_click=confirm_action,
+                # Mirror the initial Confirm button's belt-and-suspenders
+                # guard so a rapid double-click on Retry during an in-flight
+                # call can't fire a second apply. ``SetState("pending", True)``
+                # in ``confirm_action`` flips state before re-render, but
+                # the explicit ``disabled`` binding closes any iframe
+                # propagation gap.
+                disabled=Rx("pending") | Rx("cancelled"),
+            )
+        with Else():
+            Button(
+                label=confirm_label,
+                variant="default",
+                on_click=confirm_action,
+                disabled=Rx("pending") | Rx("cancelled"),
+            )
+
+        Button(
+            label="Cancel",
+            variant="outline",
+            on_click=cancel_action,
+            disabled=Rx("pending") | Rx("applied") | Rx("cancelled"),
+        )
 
 
 def _is_overdue(due_date: str | None) -> bool:
@@ -208,11 +377,14 @@ def build_order_detail_ui(
             if history:
                 Separator()
                 Muted(content="History")
-                with ForEach("order.history"), Row(gap=2):
-                    Text(content="{{ created_at }}")
-                    Text(content="{{ event }}")
-                    Text(content="{{ status_name }}")
-                    Text(content="{{ comment }}")
+                # Inside ForEach, bare ``{{ field }}`` resolves against
+                # parent state, not the row. Capture the LoopItem so each
+                # cell binds to ``$item.field``.
+                with ForEach("order.history") as entry, Row(gap=2):
+                    Text(content=entry.created_at)
+                    Text(content=entry.event)
+                    Text(content=entry.status_name)
+                    Text(content=entry.comment)
             else:
                 Separator()
                 Muted(content="No history entries.")
@@ -292,19 +464,19 @@ def build_status_change_preview_ui(
     order_id = preview.get("order_id")
     comment = preview.get("comment")
     public = bool(preview.get("public"))
-    valid = bool(preview.get("valid", True))
-    viable_codes = preview.get("viable_status_codes") or []
+    if not bool(preview.get("valid", True)):
+        return _build_invalid_status_change_ui(
+            preview, current_color=current_color, new_color=new_color
+        )
     # Re-hydrate as the schema so its ``recipients_text`` is the single source
     # of truth for both the UI and the markdown fallback rendered by orders.py.
     recipients_text = StatusChangePreview.model_validate(preview).recipients_text()
 
-    with PrefabApp(state={"preview": preview}, css_class="p-4") as app, Card():
+    state: dict[str, Any] = {"preview": preview, **_PREVIEW_STATE_INIT}
+    with PrefabApp(state=state, css_class="p-4") as app, Card():
         with CardHeader(), Row(gap=2):
             CardTitle(content=f"Preview: order {order_id} status change")
-            Badge(
-                label="INVALID TRANSITION" if not valid else "PREVIEW",
-                variant="destructive" if not valid else "secondary",
-            )
+            Badge(label="PREVIEW", variant="secondary")
 
         with CardContent(), Column(gap=3):
             with Row(gap=3):
@@ -320,21 +492,6 @@ def build_status_change_preview_ui(
                     new_color,
                 )
 
-            if not valid:
-                Separator()
-                Text(
-                    content=(
-                        f"⚠ Not a viable transition from "
-                        f"`{preview.get('current_status_code') or '—'}`. "
-                        f"Viable codes: "
-                        + (
-                            ", ".join(f"`{c}`" for c in viable_codes)
-                            if viable_codes
-                            else "_(none)_"
-                        )
-                    ),
-                )
-
             if comment:
                 Separator()
                 with Row(gap=2):
@@ -347,34 +504,85 @@ def build_status_change_preview_ui(
 
             Separator()
             Metric(label="Emails to", value=recipients_text)
+            _render_error_block()
+
+        with CardFooter():
+            _render_confirm_footer(
+                confirm_label="Confirm change",
+                confirm_action=_build_confirm_action(
+                    "update_order_status",
+                    {
+                        "order_id": "{{ preview.order_id }}",
+                        "status_code": "{{ preview.new_status_code }}",
+                        "comment": "{{ preview.comment }}",
+                        "public": "{{ preview.public }}",
+                        "email_customer": "{{ preview.email_customer }}",
+                        "email_additional": "{{ preview.email_additional }}",
+                        "confirm": True,
+                    },
+                ),
+                cancel_action=_build_cancel_action("Status change cancelled"),
+                applied_label="Status updated",
+            )
+    return app
+
+
+def _build_invalid_status_change_ui(
+    preview: dict[str, Any],
+    *,
+    current_color: str | None,
+    new_color: str | None,
+) -> PrefabApp:
+    """Render the destructive-warning card for an invalid status transition.
+
+    The confirm rail is intentionally absent — agents that picked an
+    unreachable ``new_status_code`` see the viable codes and a button that
+    refetches them, but cannot fire the apply.
+    """
+    order_id = preview.get("order_id")
+    viable_codes = preview.get("viable_status_codes") or []
+
+    with PrefabApp(state={"preview": preview}, css_class="p-4") as app, Card():
+        with CardHeader(), Row(gap=2):
+            CardTitle(content=f"Preview: order {order_id} status change")
+            Badge(label="INVALID TRANSITION", variant="destructive")
+
+        with CardContent(), Column(gap=3):
+            with Row(gap=3):
+                _status_chip(
+                    preview.get("current_status_code"),
+                    preview.get("current_status_name"),
+                    current_color,
+                )
+                Text(content="→")
+                _status_chip(
+                    preview.get("new_status_code"),
+                    preview.get("new_status_name"),
+                    new_color,
+                )
+            Separator()
+            Text(
+                content=(
+                    f"⚠ Not a viable transition from "
+                    f"`{preview.get('current_status_code') or '—'}`. "
+                    f"Viable codes: "
+                    + (
+                        ", ".join(f"`{c}`" for c in viable_codes)
+                        if viable_codes
+                        else "_(none)_"
+                    )
+                ),
+            )
 
         with CardFooter(), Row(gap=2):
-            if valid:
-                Button(
-                    label="Confirm change",
-                    variant="default",
-                    on_click=CallTool(
-                        "update_order_status",
-                        arguments={
-                            "order_id": "{{ preview.order_id }}",
-                            "status_code": "{{ preview.new_status_code }}",
-                            "comment": "{{ preview.comment }}",
-                            "public": "{{ preview.public }}",
-                            "email_customer": "{{ preview.email_customer }}",
-                            "email_additional": "{{ preview.email_additional }}",
-                            "confirm": True,
-                        },
-                    ),
-                )
-            else:
-                Button(
-                    label="See viable transitions",
-                    variant="default",
-                    on_click=CallTool(
-                        "get_viable_statuses",
-                        arguments={"order_id": order_id},
-                    ),
-                )
+            Button(
+                label="See viable transitions",
+                variant="default",
+                on_click=CallTool(
+                    "get_viable_statuses",
+                    arguments={"order_id": order_id},
+                ),
+            )
             Button(
                 label="Cancel",
                 variant="outline",
@@ -403,7 +611,8 @@ def build_comment_preview_ui(preview: dict[str, Any]) -> PrefabApp:
     comment = preview.get("comment") or ""
     public = bool(preview.get("public"))
 
-    with PrefabApp(state={"preview": preview}, css_class="p-4") as app, Card():
+    state = {"preview": preview, **_PREVIEW_STATE_INIT}
+    with PrefabApp(state=state, css_class="p-4") as app, Card():
         with CardHeader(), Row(gap=2):
             CardTitle(content=f"Preview: comment on order {order_id}")
             Badge(label="PREVIEW", variant="secondary")
@@ -419,25 +628,22 @@ def build_comment_preview_ui(preview: dict[str, Any]) -> PrefabApp:
                     label="public" if public else "private",
                     variant="info" if public else "outline",
                 )
+            _render_error_block()
 
-        with CardFooter(), Row(gap=2):
-            Button(
-                label="Confirm comment",
-                variant="default",
-                on_click=CallTool(
+        with CardFooter():
+            _render_confirm_footer(
+                confirm_label="Confirm comment",
+                confirm_action=_build_confirm_action(
                     "add_order_comment",
-                    arguments={
+                    {
                         "order_id": "{{ preview.order_id }}",
                         "comment": "{{ preview.comment }}",
                         "public": "{{ preview.public }}",
                         "confirm": True,
                     },
                 ),
-            )
-            Button(
-                label="Cancel",
-                variant="outline",
-                on_click=ShowToast(message="Comment cancelled", variant="info"),
+                cancel_action=_build_cancel_action("Comment cancelled"),
+                applied_label="Comment added",
             )
     return app
 
@@ -458,7 +664,8 @@ def build_due_date_change_preview_ui(preview: dict[str, Any]) -> PrefabApp:
     current_label = f"{current} → {current_to}" if current_to else current
     new_label = f"{new_due} → {new_to}" if new_to else new_due
 
-    with PrefabApp(state={"preview": preview}, css_class="p-4") as app, Card():
+    state = {"preview": preview, **_PREVIEW_STATE_INIT}
+    with PrefabApp(state=state, css_class="p-4") as app, Card():
         with CardHeader(), Row(gap=2):
             CardTitle(content=f"Preview: due date for order {order_id}")
             Badge(label="PREVIEW", variant="secondary")
@@ -474,25 +681,22 @@ def build_due_date_change_preview_ui(preview: dict[str, Any]) -> PrefabApp:
                 with Column(gap=1):
                     Muted(content="Proposed")
                     Text(content=new_label)
+            _render_error_block()
 
-        with CardFooter(), Row(gap=2):
-            Button(
-                label="Confirm due date",
-                variant="default",
-                on_click=CallTool(
+        with CardFooter():
+            _render_confirm_footer(
+                confirm_label="Confirm due date",
+                confirm_action=_build_confirm_action(
                     "update_order_due_date",
-                    arguments={
+                    {
                         "order_id": "{{ preview.order_id }}",
                         "due_date": "{{ preview.new_due_date }}",
                         "due_date_to": "{{ preview.new_due_date_to }}",
                         "confirm": True,
                     },
                 ),
-            )
-            Button(
-                label="Cancel",
-                variant="outline",
-                on_click=ShowToast(message="Due date change cancelled", variant="info"),
+                cancel_action=_build_cancel_action("Due date change cancelled"),
+                applied_label="Due date updated",
             )
     return app
 
@@ -517,7 +721,8 @@ def build_bulk_status_change_preview_ui(preview: dict[str, Any]) -> PrefabApp:
 
     recipients_text = _BSP.model_validate(preview).recipients_text()
 
-    with PrefabApp(state={"preview": preview}, css_class="p-4") as app, Card():
+    state = {"preview": preview, **_PREVIEW_STATE_INIT}
+    with PrefabApp(state=state, css_class="p-4") as app, Card():
         with CardHeader(), Row(gap=2):
             CardTitle(content=f"Preview: bulk status change ({order_count} orders)")
             Badge(label="PREVIEW", variant="secondary")
@@ -546,14 +751,14 @@ def build_bulk_status_change_preview_ui(preview: dict[str, Any]) -> PrefabApp:
 
             Separator()
             Metric(label="Emails to", value=recipients_text)
+            _render_error_block()
 
-        with CardFooter(), Row(gap=2):
-            Button(
-                label=f"Confirm bulk update ({order_count})",
-                variant="default",
-                on_click=CallTool(
+        with CardFooter():
+            _render_confirm_footer(
+                confirm_label=f"Confirm bulk update ({order_count})",
+                confirm_action=_build_confirm_action(
                     "bulk_update_order_status",
-                    arguments={
+                    {
                         "order_ids": "{{ preview.order_ids }}",
                         "status_code": "{{ preview.target_status_code }}",
                         "comment": "{{ preview.comment }}",
@@ -563,11 +768,8 @@ def build_bulk_status_change_preview_ui(preview: dict[str, Any]) -> PrefabApp:
                         "confirm": True,
                     },
                 ),
-            )
-            Button(
-                label="Cancel",
-                variant="outline",
-                on_click=ShowToast(message="Bulk update cancelled", variant="info"),
+                cancel_action=_build_cancel_action("Bulk update cancelled"),
+                applied_label=f"Updated {order_count} orders",
             )
     return app
 

--- a/statuspro_mcp_server/tests/tools/test_prefab_ui.py
+++ b/statuspro_mcp_server/tests/tools/test_prefab_ui.py
@@ -21,6 +21,7 @@ button is wired with ``CallTool(...)``.
 from __future__ import annotations
 
 import json
+from collections.abc import Iterator
 from typing import Any
 
 from prefab_ui.app import PrefabApp
@@ -46,30 +47,52 @@ def _assert_renders(app: PrefabApp) -> None:
     _envelope(app)
 
 
-def _find_tool_calls(envelope: dict[str, Any]) -> list[dict[str, Any]]:
-    """Walk ``envelope`` and collect every ``toolCall`` action payload.
+def _walk_nodes(envelope: Any) -> Iterator[dict[str, Any]]:
+    """Yield every dict node in ``envelope`` in document order.
 
-    Each entry has the shape produced by Prefab's ``CallTool`` action:
-    ``{"action": "toolCall", "tool": "...", "arguments": {...}}``. Returns
-    them in document order. Used by the assertion helpers below to check
-    that a builder wires a CallTool with specific tool name + args (vs. a
-    substring match on the serialized JSON, which can be satisfied by the
-    preview model's ``action`` field that lives in iframe ``state``).
+    The Prefab wire envelope nests dicts and lists; this generator visits
+    them depth-first so callers can scan for action payloads, component
+    types, or other structural matches without re-implementing the walk.
     """
-    found: list[dict[str, Any]] = []
+    if isinstance(envelope, dict):
+        yield envelope
+        for v in envelope.values():
+            yield from _walk_nodes(v)
+    elif isinstance(envelope, list):
+        for item in envelope:
+            yield from _walk_nodes(item)
 
-    def walk(node: Any) -> None:
-        if isinstance(node, dict):
-            if node.get("action") == "toolCall" and "tool" in node:
-                found.append(node)
-            for v in node.values():
-                walk(v)
-        elif isinstance(node, list):
-            for item in node:
-                walk(item)
 
-    walk(envelope)
-    return found
+def _find_confirm_button(envelope: dict[str, Any]) -> dict[str, Any] | None:
+    """Return the first Button with ``"Confirm"`` in its label.
+
+    Targets the *initial* Confirm button (the footer Condition's ``else``
+    branch) so its ``onClick`` chain can be asserted on directly without
+    hardcoding the path through Condition.else.
+    """
+    return next(
+        (
+            n
+            for n in _walk_nodes(envelope)
+            if n.get("type") == "Button" and "Confirm" in str(n.get("label", ""))
+        ),
+        None,
+    )
+
+
+def _find_tool_calls(envelope: dict[str, Any]) -> list[dict[str, Any]]:
+    """Collect every ``toolCall`` action payload in ``envelope``.
+
+    Used to assert against the actual button-click wiring, which would be
+    invisible to a substring scan because the preview model's ``action``
+    field lives in iframe ``state`` and would satisfy the substring check
+    even when the Confirm button is mis-wired.
+    """
+    return [
+        n
+        for n in _walk_nodes(envelope)
+        if n.get("action") == "toolCall" and "tool" in n
+    ]
 
 
 def test_build_orders_table_ui_renders_with_drill_down_action():
@@ -164,16 +187,13 @@ def test_build_status_change_preview_ui_renders_with_confirm_action():
         current_color="pink",
         new_color="green",
     )
-    # The Confirm button's CallTool action drives the second half of the
-    # two-step mutation flow. The assertion target is the toolCall action
-    # payload itself (not a substring of the wire envelope), since the
-    # preview model's `action` field is also "update_order_status" and
-    # lives in iframe state — a substring assertion would pass even if
-    # the Confirm button were mis-wired.
+    # Assert on the toolCall payload (not a substring) — the preview model's
+    # ``action`` field is also "update_order_status" and lives in iframe state,
+    # so a substring match would pass even with a mis-wired button.
     tool_calls = _find_tool_calls(_envelope(app))
     update_calls = [tc for tc in tool_calls if tc["tool"] == "update_order_status"]
-    assert len(update_calls) == 1, (
-        f"expected exactly one update_order_status CallTool action; got {tool_calls}"
+    assert update_calls, (
+        f"expected an update_order_status CallTool action; got {tool_calls}"
     )
     args = update_calls[0]["arguments"]
     assert args.get("confirm") is True
@@ -242,9 +262,7 @@ def test_build_comment_preview_ui_renders_with_confirm_action():
     # carrying confirm=true.
     tool_calls = _find_tool_calls(envelope)
     confirm_calls = [tc for tc in tool_calls if tc["tool"] == "add_order_comment"]
-    assert len(confirm_calls) == 1, (
-        "expected exactly one add_order_comment toolCall action"
-    )
+    assert confirm_calls, "expected an add_order_comment toolCall action"
     args = confirm_calls[0]["arguments"]
     assert args.get("confirm") is True
     # The visible content stays as substring assertions — those legitimately
@@ -303,7 +321,7 @@ def test_build_due_date_change_preview_ui_shows_before_after():
     # and pin the new_due_date → due_date arg rename.
     tool_calls = _find_tool_calls(envelope)
     confirm_calls = [tc for tc in tool_calls if tc["tool"] == "update_order_due_date"]
-    assert len(confirm_calls) == 1
+    assert confirm_calls, "expected an update_order_due_date toolCall action"
     args = confirm_calls[0]["arguments"]
     assert args.get("confirm") is True
     assert args.get("due_date") == "{{ preview.new_due_date }}"
@@ -337,7 +355,7 @@ def test_build_bulk_status_change_preview_ui_shows_count_and_target():
     confirm_calls = [
         tc for tc in tool_calls if tc["tool"] == "bulk_update_order_status"
     ]
-    assert len(confirm_calls) == 1
+    assert confirm_calls, "expected a bulk_update_order_status toolCall action"
     args = confirm_calls[0]["arguments"]
     assert args.get("confirm") is True
     assert args.get("status_code") == "{{ preview.target_status_code }}"
@@ -366,3 +384,204 @@ def test_build_bulk_status_change_preview_ui_truncates_long_id_list():
     # First 10 ids visible (1, 2, ..., 10); last id (50) hidden behind "+40 more"
     assert "+40 more" in serialized
     assert "50" in serialized  # the count, not the id
+
+
+def test_preview_cards_wire_double_click_guard():
+    """Every preview card must seed the pending/cancelled state slots and bind
+    its Confirm button to a chain that flips ``pending=True`` *before* firing
+    the apply CallTool.
+
+    Without these, a rapid double-click on the Confirm button fires two
+    identical mutation calls — e.g. two bulk status updates that double-send
+    notification emails to the customer. The SetState in the on_click chain
+    is the spam guard; the explicit ``disabled={{ pending || cancelled }}``
+    binding on the button is belt-and-suspenders.
+    """
+    builders = [
+        (
+            build_status_change_preview_ui,
+            {
+                "order_id": 1,
+                "current_status_code": "st000002",
+                "new_status_code": "st000003",
+                "comment": None,
+                "public": False,
+                "email_customer": True,
+                "email_additional": False,
+                "valid": True,
+                "viable_status_codes": ["st000003"],
+            },
+        ),
+        (
+            build_comment_preview_ui,
+            {
+                "order_id": 1,
+                "order_summary": {"id": 1},
+                "comment": "hi",
+                "public": False,
+            },
+        ),
+        (
+            build_due_date_change_preview_ui,
+            {
+                "order_id": 1,
+                "order_summary": {"id": 1},
+                "current_due_date": "2026-01-01",
+                "new_due_date": "2026-02-01",
+            },
+        ),
+        (
+            build_bulk_status_change_preview_ui,
+            {
+                "order_ids": [1, 2],
+                "order_count": 2,
+                "target_status_code": "st000003",
+                "target_status_name": "Shipped",
+                "comment": None,
+                "public": False,
+                "email_customer": True,
+                "email_additional": False,
+            },
+        ),
+    ]
+    for builder, preview in builders:
+        envelope = _envelope(builder(preview))
+        state = envelope.get("state") or {}
+        # The four state slots the footer's If/Elif blocks bind to.
+        assert state.get("pending") is False, (
+            f"{builder.__name__} must seed pending=False"
+        )
+        assert state.get("cancelled") is False, (
+            f"{builder.__name__} must seed cancelled=False"
+        )
+        assert state.get("applied") is False, (
+            f"{builder.__name__} must seed applied=False"
+        )
+        # Locate the Confirm button (lives in the footer Condition's ``else``
+        # branch — the initial Preview state) and verify its on_click chain
+        # leads with ``SetState("pending", True)``. A substring match on the
+        # whole envelope wouldn't catch a regression that moved the guard
+        # SetState into ``on_success``/``on_error`` (where ``pending`` is
+        # also referenced, but for clearing rather than guarding).
+        confirm = _find_confirm_button(envelope)
+        assert confirm is not None, (
+            f"{builder.__name__}: could not locate Confirm button in footer"
+        )
+        on_click = confirm.get("onClick") or []
+        assert on_click and isinstance(on_click, list), (
+            f"{builder.__name__}: Confirm button has no on_click chain"
+        )
+        assert (
+            on_click[0].get("action") == "setState"
+            and on_click[0].get("key") == "pending"
+            and on_click[0].get("value") is True
+        ), (
+            f"{builder.__name__}: on_click[0] must be SetState(pending, True); "
+            f"got {on_click[0]}"
+        )
+        # The disabled binding gates rapid clicks even if the SetState above
+        # is somehow delayed (belt-and-suspenders). It must reference both
+        # ``pending`` and ``cancelled``.
+        disabled = str(confirm.get("disabled") or "")
+        assert "pending" in disabled and "cancelled" in disabled, (
+            f"{builder.__name__}: Confirm button disabled binding must include "
+            f"both pending and cancelled; got {disabled!r}"
+        )
+
+
+def test_confirm_footer_state_precedence():
+    """The footer state machine must check ``cancelled`` before ``error`` so a
+    Cancel click after an apply failure locks the footer down. Otherwise
+    ``cancelled=True`` would be set but the Retry button would keep showing
+    because ``error`` is still truthy from the prior failure.
+
+    Pinning the case order here so a future shuffle of the If/Elif chain
+    can't silently regress the user-cancel-after-error flow.
+    """
+    app = build_comment_preview_ui(
+        {
+            "order_id": 1,
+            "order_summary": {"id": 1},
+            "comment": "hi",
+            "public": False,
+        },
+    )
+    envelope = _envelope(app)
+    # Find the footer Condition (the one with multiple cases — the error-block
+    # uses an If too but only has a single ``{{ error }}`` case).
+    footer_condition = next(
+        (
+            n
+            for n in _walk_nodes(envelope)
+            if n.get("type") == "Condition" and len(n.get("cases") or []) > 1
+        ),
+        None,
+    )
+    assert footer_condition is not None, "footer Condition not found in envelope"
+    whens = [c.get("when") for c in footer_condition["cases"]]
+    cancelled_idx = next(
+        (i for i, w in enumerate(whens) if w and "cancelled" in str(w)), -1
+    )
+    error_idx = next((i for i, w in enumerate(whens) if w and "error" in str(w)), -1)
+    assert cancelled_idx >= 0 and error_idx >= 0, (
+        f"footer must have both cancelled and error cases; got whens={whens}"
+    )
+    assert cancelled_idx < error_idx, (
+        f"cancelled case must precede error case in the footer state machine; "
+        f"got cancelled@{cancelled_idx}, error@{error_idx} in {whens}"
+    )
+
+
+def test_retry_button_has_double_click_guard():
+    """The Retry button (rendered in the error state) must share the initial
+    Confirm button's ``disabled=Rx(pending) | Rx(cancelled)`` belt-and-
+    suspenders binding. Without it, a rapid double-click on Retry during an
+    in-flight retry can fire a second apply call before the iframe re-renders.
+    """
+    app = build_comment_preview_ui(
+        {
+            "order_id": 1,
+            "order_summary": {"id": 1},
+            "comment": "hi",
+            "public": False,
+        },
+    )
+    envelope = _envelope(app)
+    retry = next(
+        (
+            n
+            for n in _walk_nodes(envelope)
+            if n.get("type") == "Button" and n.get("label") == "Retry"
+        ),
+        None,
+    )
+    assert retry is not None, "Retry button missing from footer state machine"
+    disabled = str(retry.get("disabled") or "")
+    assert "pending" in disabled and "cancelled" in disabled, (
+        f"Retry button disabled binding must include both pending and "
+        f"cancelled; got {disabled!r}"
+    )
+
+
+def test_status_change_preview_invalid_does_not_seed_apply_state():
+    """When ``valid=False`` the Confirm button is replaced with a "See viable
+    transitions" button — the apply rail isn't live, so the pending/applied
+    state slots shouldn't appear in the envelope (no apply to guard).
+    """
+    app = build_status_change_preview_ui(
+        {
+            "order_id": 1,
+            "current_status_code": "st000002",
+            "new_status_code": "st000099",
+            "comment": None,
+            "public": False,
+            "email_customer": True,
+            "email_additional": True,
+            "valid": False,
+            "viable_status_codes": ["st000003"],
+        },
+    )
+    envelope = _envelope(app)
+    state = envelope.get("state") or {}
+    assert "pending" not in state
+    assert "applied" not in state


### PR DESCRIPTION
## Summary

Fixes two issues surfaced by Claude Desktop rendering of MCP-Apps preview cards.

**Confirm-button feedback + double-click safety.** The four preview cards (status change, comment, due date, bulk status) now render a footer state machine: Preview → Pending… → Applied / Retry / Cancelled. `SetState("pending", True)` flips synchronously before the apply `CallTool` fires, so a rapid second click can't trigger a duplicate mutation. `disabled=Rx("pending") | Rx("cancelled")` on the button is the belt-and-suspenders binding. `on_success` pushes the structured result into the agent's model context via `UpdateContext`; `on_error` surfaces the failure inline via a shadcn `Alert` (matching katana's pattern) and swaps the primary button to a Retry affordance.

**ForEach history templating.** `build_order_detail_ui` was rendering raw `{{ created_at }}` text literals because inside `ForEach` the binding scope is `$item`, not parent state. Capture the loop via `as entry:` so each cell binds to the row.

Ports the direct-apply confirmation rail from sibling katana-openapi-client.

## Test plan

- [x] `uv run poe check` — full validation (test + lint + typecheck + format) passes
- [x] 14/14 tests in `test_prefab_ui.py` pass, including two new ones:
  - `test_preview_cards_wire_double_click_guard` — pins the SetState guard and seeded state across all four preview cards
  - `test_status_change_preview_invalid_does_not_seed_apply_state` — invalid-transition path doesn't seed pending/applied
- [ ] Manual: install MCPB bundle in Claude Desktop, trigger an update_order_status preview, double-click Confirm rapidly — only one CallTool fires
- [ ] Manual: `get_order` on an order with history — history rows render with actual timestamps/events, not raw `{{ field }}` literals

🤖 Generated with [Claude Code](https://claude.com/claude-code)