### PR TITLE
fix(ci): use GitHub App token for upstream OpenAPI sync PR

### DIFF
--- a/.github/workflows/sync-openapi-spec.yml
+++ b/.github/workflows/sync-openapi-spec.yml
@@ -17,8 +17,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   sync:
@@ -56,10 +55,21 @@ jobs:
             git diff --stat docs/statuspro-openapi.upstream.yaml
           fi
 
+      - name: Mint GitHub App installation token
+        if: steps.detect.outputs.changed == 'true'
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
       - name: Open PR if upstream changed
         if: steps.detect.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v8
         with:
+          token: ${{ steps.app-token.outputs.token }}
           base: main
           branch: chore/upstream-openapi-spec-sync
           delete-branch: true


### PR DESCRIPTION
## Summary

`sync-openapi-spec.yml` opens a PR via `peter-evans/create-pull-request` using the default `GITHUB_TOKEN`. GitHub deliberately prevents `GITHUB_TOKEN`-authored PRs/pushes from triggering downstream `pull_request`/`push` workflows. `main` has required status checks (`quality`, `test (3.12)`, `test (3.13)`, `test (3.14)`) that only run via `ci.yml`'s `pull_request` trigger — so PRs opened by this workflow could never accumulate the checks needed to satisfy branch protection and merge.

This mints a scoped installation token from the `dougborg-release-please` GitHub App (already installed on the account, credentials already present as the `RELEASE_PLEASE_APP_ID` variable and `RELEASE_PLEASE_APP_PRIVATE_KEY` secret — not touched by this PR) and passes it to `create-pull-request` in place of the default token.

- Added an `actions/create-github-app-token@v3` step, scoped down to `permission-contents: write` + `permission-pull-requests: write` (flagged by `zizmor`'s `github-app` audit otherwise — an unscoped App token inherits the App's full installation permissions).
- Tightened the job's top-level `permissions:` from `contents: write` / `pull-requests: write` down to `contents: read`, since the App token (not the job's `GITHUB_TOKEN`) now carries the elevated permissions for the PR-creation step.

## What was deliberately left unchanged

- `release.yml`, `release-ts.yml`, `release-mcp.yml`, `update-mcp-dependency.yml` already authenticate their GitHub-side actions (checkout-for-push, semantic-release, tagging) with the pre-existing `SEMANTIC_RELEASE_TOKEN` PAT, which already solves the same "trigger downstream workflows" problem. No change needed there.
- `release-mcp.yml`'s `gh release upload` step and `release.yml`'s GHCR `docker/login-action` step both use the default `GITHUB_TOKEN`, but only for asset upload / registry auth against an already-created release — nothing downstream depends on those triggering further workflows, so they're intentionally untouched.
- No package-registry publishing credentials (PyPI OIDC, npm OIDC) were touched.
- No secrets/variables were created, modified, or deleted.

## Test plan

- [ ] `zizmor .github/workflows/sync-openapi-spec.yml` — confirmed the `github-app` (unscoped token) finding is resolved after adding `permission-*` inputs; remaining `unpinned-uses` findings are pre-existing repo-wide style (every action in this repo is pinned by tag, not SHA) and out of scope for this change.
- [ ] Trigger the workflow via `workflow_dispatch` (or wait for the Monday 09:00 UTC cron) and confirm the resulting PR shows up authored by the App, with `ci.yml`'s required checks running on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRhJ5dF3N3z7X63aRaDBcQ