### PR TITLE
fix(release): drop PSR build_command that cannot run in its container

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -378,7 +378,11 @@ upload_to_repository = false
 remove_dist = false
 commit_author = "github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
 commit_message = "chore(release): client v{version}"
-build_command = "pnpm exec prettier --write docs/CHANGELOG.md"
+# Empty: nothing to run here. Distributions are built by `uv build` in the
+# release workflow, and docs/CHANGELOG.md is in .prettierignore, so formatting
+# it was a no-op that only ever failed — `pnpm` does not exist inside the
+# python-semantic-release container (exit 127). See #124.
+build_command = ""
 major_on_zero = false
 allow_zero_version = true
 tag_format = "client-v{version}"

--- a/statuspro_mcp_server/pyproject.toml
+++ b/statuspro_mcp_server/pyproject.toml
@@ -83,7 +83,11 @@ upload_to_repository = false
 remove_dist = false
 commit_author = "github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
 commit_message = "chore(release): mcp v{version}"
-build_command = "pnpm exec prettier --write CHANGELOG.md"
+# Empty: nothing to run here. The MCP distribution is built by `uv build` in
+# the release workflow, and CHANGELOG.md is in .prettierignore, so formatting
+# it was a no-op that only ever failed — `pnpm` does not exist inside the
+# python-semantic-release container (exit 127). See #124.
+build_command = ""
 major_on_zero = false
 allow_zero_version = true
 tag_format = "mcp-v{version}"


### PR DESCRIPTION
## Problem

Every release fails. Run [30174334660](https://github.com/dougborg/statuspro-openapi-client/actions/runs/30174334660), both `release-client` and `release-mcp`:

```
CalledProcessError: Command '['bash', '-c', 'pnpm exec prettier --write docs/CHANGELOG.md']'
    returned non-zero exit status 127.
ERROR    Build command failed with exit code 127       version.py:305
Build failed, aborting release
```

`python-semantic-release` runs as a Docker container action containing Python and `pip` but no Node — so `pnpm` is not found (127) and PSR aborts before cutting a version. Nothing in the workflow can install into that container; `setup-uv`/`setup-node` run on the runner, not inside the action.

This was masked until now: the pipeline could not authenticate at all until #121 replaced the dead `SEMANTIC_RELEASE_TOKEN` PAT with the GitHub App.

## Fix

Set `build_command = ""` in both `pyproject.toml` and `statuspro_mcp_server/pyproject.toml`.

Three reasons this is a removal rather than a replacement:

1. **It was a no-op.** `.prettierignore` already contains `CHANGELOG.md` and `**/CHANGELOG.md` under the comment "Release-managed changelogs", so `format-markdown-check` never inspects the files this command formatted. Both changelogs are prettier-clean today.
2. **It was not building anything.** PSR's `build_command` is meant to build distributions. This repo builds them separately with `uv build` (`release.yml:118` for the client, `release.yml:193` for the MCP), so nothing downstream depends on it.
3. **The in-container alternative would be inconsistent.** katana/stocktrim use `pip install mdformat ... && mdformat ...`, which does work in the container — but this repo standardises on prettier for markdown, and since the changelogs are ignored anyway, adopting a second formatter would add a dependency with no verifiable effect.

Discussed in #124, including a correction: I initially believed switching to mdformat would break `format-markdown-check`. It would not, because the changelogs are ignored — which is also what makes plain removal the simplest correct answer.

## What to expect on the first green run

This repo has exactly one tag (`client-v0.1.0`) and 35 commits since it. The MCP package has never been released — there is no `mcp-v*` tag — so its first publish happens on the first successful run.

`major_on_zero = false` and `allow_zero_version = true` are set in both configs, so the one `feat(mcp)!:` commit will not produce a `1.0.0`; versions stay in `0.x`. `statuspro_mcp_server` pins `statuspro-openapi-client>=0.1.0`, which is satisfiable against the published `0.1.0`.

Publishing uses OIDC trusted publishing for both PyPI (`pypa/gh-action-pypi-publish`) and npm (`pnpm publish`), so no registry tokens are involved. If the trusted publisher was never registered on the PyPI/npm side, that will surface as the next failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRhJ5dF3N3z7X63aRaDBcQ