### PR TITLE
fix(tests): align MCP package asyncio_mode with the root

### DIFF
--- a/statuspro_mcp_server/pyproject.toml
+++ b/statuspro_mcp_server/pyproject.toml
@@ -69,7 +69,7 @@ packages = ["src/statuspro_mcp"]
 # Pytest Configuration (Native TOML - pytest 9.0+)
 [tool.pytest]
 testpaths = ["tests"]
-asyncio_mode = "strict"
+asyncio_mode = "auto"
 markers = [
     "unit: Unit tests with mocks",
     "integration: Integration tests requiring API key",


### PR DESCRIPTION
## Preventive, not a bug fix — nothing is broken today

`statuspro_mcp_server/pyproject.toml:72` declares `asyncio_mode = "strict"`; the root declares `"auto"`. pytest resolves `rootdir`/`configfile` from the target path, so `pytest statuspro_mcp_server/tests` and a root-level run read **different** configs.

Scope, verified rather than assumed:

| Invocation | Before | After |
|---|---|---|
| `pytest statuspro_mcp_server/tests` | 145 passed | 145 passed |
| `pytest -n 4 -m 'not docs and not schema_validation and not integration'` | 300 passed, 1 skipped | 300 passed, 1 skipped |

This package is strict-clean — all 14 of its async tests carry `@pytest.mark.asyncio` — so both settings work.

## Why change it at all

The sibling repo `frontapp-openapi-client` has the identical divergence, and there it **does** break: 136 tests fail when run from the package directory, because its tests are not strict-clean (dougborg/frontapp-openapi-client#166). Here it is a latent hazard — it holds only while every future async test remembers its marker, and CI would not catch a regression because it only runs pytest from the root.

I deliberately did **not** delete the `[tool.pytest]` block; it also carries `testpaths` and the `unit`/`integration` marker registrations.

## Follow-up worth considering (not in this PR)

CI only exercises the root invocation, which is why this drift is invisible. A job running the MCP package's tests from inside its own directory would catch it directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRhJ5dF3N3z7X63aRaDBcQ