### PR TITLE
fix(release): invoke publish from release-please, not from tags

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,8 @@
 name: Publish
 
-# The only workflow that builds and ships artifacts. Triggered exclusively
-# by the tags release-please creates when its release PR merges
-# (client-v*, mcp-v*, ts-v*). Nothing here ever pushes to main.
+# The only workflow that builds and ships artifacts. Invoked by
+# release-please.yml after it creates the draft releases, one call per
+# released component. Nothing here ever pushes to main.
 #
 # release-please creates each GitHub Release as a DRAFT (see
 # release-please-config.json "draft": true). Draft releases accept asset
@@ -28,23 +28,34 @@ name: Publish
 # has never been published) - the publish-ts job will fail until one is
 # registered for workflow `publish.yml`, job `publish-ts`.
 
+# Invoked by release-please.yml once it has created the draft releases, and
+# manually re-runnable via workflow_dispatch. It is NOT tag-triggered: the
+# releases are created as drafts, and a draft release does not create its git
+# tag until it is published, so `on: push: tags` would never fire.
 on:
-  push:
-    tags:
-      - 'client-v*'
-      - 'mcp-v*'
-      - 'ts-v*'
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Release tag to publish, e.g. client-v0.3.0'
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to publish, e.g. client-v0.3.0'
+        required: true
+        type: string
 
 permissions: {}
 
 concurrency:
-  group: publish-${{ github.ref }}
+  group: publish-${{ inputs.tag }}
   cancel-in-progress: false
 
 jobs:
   publish-client:
     name: Publish client to PyPI
-    if: startsWith(github.ref_name, 'client-v')
+    if: startsWith(inputs.tag, 'client-v')
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -52,7 +63,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.ref_name }}
+          # The tag does not exist yet: the release is still a draft and GitHub
+          # only creates the tag when it is published. Build from the commit
+          # release-please released from.
+          ref: ${{ github.sha }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -72,16 +86,16 @@ jobs:
       - name: Attach build artifacts to draft release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload "${{ github.ref_name }}" dist/* --clobber
+        run: gh release upload "${{ inputs.tag }}" dist/* --clobber
 
       - name: Publish the (now immutable) release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release edit "${{ github.ref_name }}" --draft=false
+        run: gh release edit "${{ inputs.tag }}" --draft=false
 
   publish-mcp:
     name: Publish MCP server to PyPI
-    if: startsWith(github.ref_name, 'mcp-v')
+    if: startsWith(inputs.tag, 'mcp-v')
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -89,7 +103,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.ref_name }}
+          # The tag does not exist yet: the release is still a draft and GitHub
+          # only creates the tag when it is published. Build from the commit
+          # release-please released from.
+          ref: ${{ github.sha }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -128,17 +145,17 @@ jobs:
       - name: Attach build artifacts to draft release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload "${{ github.ref_name }}" dist/* "${{ steps.mcpb.outputs.artifact }}" --clobber
+        run: gh release upload "${{ inputs.tag }}" dist/* "${{ steps.mcpb.outputs.artifact }}" --clobber
 
       - name: Publish the (now immutable) release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release edit "${{ github.ref_name }}" --draft=false
+        run: gh release edit "${{ inputs.tag }}" --draft=false
 
   publish-mcp-docker:
     name: Publish MCP Docker image
     needs: publish-mcp
-    if: startsWith(github.ref_name, 'mcp-v')
+    if: startsWith(inputs.tag, 'mcp-v')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -146,7 +163,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.ref_name }}
+          # The tag does not exist yet: the release is still a draft and GitHub
+          # only creates the tag when it is published. Build from the commit
+          # release-please released from.
+          ref: ${{ github.sha }}
 
       - name: Determine MCP version for tagging
         id: version
@@ -187,7 +207,7 @@ jobs:
 
   publish-ts:
     name: Publish TS client to npm
-    if: startsWith(github.ref_name, 'ts-v')
+    if: startsWith(inputs.tag, 'ts-v')
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -195,7 +215,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.ref_name }}
+          # The tag does not exist yet: the release is still a draft and GitHub
+          # only creates the tag when it is published. Build from the commit
+          # release-please released from.
+          ref: ${{ github.sha }}
 
       - uses: pnpm/action-setup@v6
 
@@ -225,9 +248,9 @@ jobs:
       - name: Attach npm tarball to draft release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload "${{ github.ref_name }}" packages/statuspro-client/dist-npm/*.tgz --clobber
+        run: gh release upload "${{ inputs.tag }}" packages/statuspro-client/dist-npm/*.tgz --clobber
 
       - name: Publish the (now immutable) release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release edit "${{ github.ref_name }}" --draft=false
+        run: gh release edit "${{ inputs.tag }}" --draft=false

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,6 +17,9 @@ concurrency:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      releases_created: ${{ steps.release.outputs.releases_created }}
+      tags: ${{ steps.tags.outputs.tags }}
     permissions:
       contents: write
       pull-requests: write
@@ -35,3 +38,35 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      # release-please creates DRAFT releases, and a draft release has no git
+      # tag until it is published - so publishing cannot be tag-triggered.
+      # Collect the tags it just created and hand them to publish.yml directly.
+      - name: Collect released tags
+        id: tags
+        if: steps.release.outputs.releases_created == 'true'
+        env:
+          RELEASE_OUTPUTS: ${{ toJSON(steps.release.outputs) }}
+        run: |
+          set -euo pipefail
+          tags=$(printf '%s' "$RELEASE_OUTPUTS" \
+            | jq -c '[to_entries[] | select(.key | endswith("--tag_name")) | .value | select(. != null and . != "")]')
+          echo "Tags to publish: $tags"
+          echo "tags=$tags" >> "$GITHUB_OUTPUT"
+
+  publish:
+    needs: release-please
+    if: needs.release-please.outputs.releases_created == 'true'
+    strategy:
+      # One call per released component; never cancel a publish mid-flight.
+      fail-fast: false
+      matrix:
+        tag: ${{ fromJSON(needs.release-please.outputs.tags) }}
+    permissions:
+      contents: write
+      id-token: write
+      packages: write
+    uses: ./.github/workflows/publish.yml
+    with:
+      tag: ${{ matrix.tag }}
+    secrets: inherit


### PR DESCRIPTION
## The bug

Merging release PR #129 created three **draft** releases — `client-v0.3.0`, `mcp-v0.2.0`, `ts-v0.2.0` — and then nothing happened. No `Publish` run, nothing published.

```console
$ gh release list
client-v0.3.0  draft=true
mcp-v0.2.0     draft=true
ts-v0.2.0      draft=true

$ git ls-remote --tags        # newest tags are still the PREVIOUS release
refs/tags/client-v0.2.0
refs/tags/mcp-v0.1.0
```

**A draft release does not create its git tag until it is published.** `publish.yml` was triggered by `on: push: tags`, so the trigger could never fire, and the releases would have stayed drafts indefinitely.

This is a circular dependency baked into the migration design (dougborg/katana-openapi-client#1002 §5.3 + §5.4): §5.4 requires `"draft": true` so assets can be attached before immutability locks the release, while §5.3 specifies tag-triggered publishing. Those two cannot both hold.

`draft: true` is the part worth keeping — it is what makes asset attachment work under immutable releases (the failure that permanently cost `stocktrim-openapi-client` its `mcp-v0.16.0` `.mcpb`, and `AirHound` its `v0.1.1` firmware). So the trigger is what changes.

## The fix

**`release-please.yml`** now collects the tags it just created and invokes `publish.yml` directly, one matrix leg per released component:

```yaml
  publish:
    needs: release-please
    if: needs.release-please.outputs.releases_created == 'true'
    strategy:
      fail-fast: false
      matrix:
        tag: ${{ fromJSON(needs.release-please.outputs.tags) }}
    uses: ./.github/workflows/publish.yml
    with:
      tag: ${{ matrix.tag }}
    secrets: inherit
```

**`publish.yml`** becomes `workflow_call` + `workflow_dispatch` (kept for manual recovery), taking the tag as an input rather than reading `github.ref_name`.

It also no longer checks out `inputs.tag`: that ref does not exist while the release is a draft. It builds from the commit release-please released from (`github.sha`), which for the `workflow_call` path is exactly the release PR's merge commit.

`fail-fast: false` so one component's publish failure cannot cancel another's mid-flight.

## Recovering the three stuck drafts

Once this merges, each can be published with:

```console
gh workflow run Publish --repo dougborg/statuspro-openapi-client -f tag=client-v0.3.0
gh workflow run Publish --repo dougborg/statuspro-openapi-client -f tag=mcp-v0.2.0
```

`ts-v0.2.0` will still fail at the registry step — no npm Trusted Publisher exists for `statuspro-client`, and npm has **no pending-publisher equivalent** to PyPI's, so one manual bootstrap publish is required before OIDC can be configured at all.

## Affects the sibling repos

`katana-openapi-client`, `stocktrim-openapi-client`, and `frontapp-openapi-client` were migrated to the same topology and have the identical defect. katana and stocktrim have release PRs open right now that would reproduce it exactly. The same fix needs to land in all three before their release PRs are merged.

## Validation

`actionlint` clean on both workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRhJ5dF3N3z7X63aRaDBcQ