### PR TITLE
fix(release): keep the .mcpb template's client pin in sync

### DIFF
--- a/.github/workflows/release-pr-prepare.yml
+++ b/.github/workflows/release-pr-prepare.yml
@@ -62,9 +62,13 @@ jobs:
           echo "Client version on this release PR: $CLIENT_VERSION"
           echo "Current MCP -> client floor: $CURRENT_FLOOR"
           if [ "$CURRENT_FLOOR" != "$CLIENT_VERSION" ]; then
+            # The .mcpb bundle carries its own copy of the dependency list and
+            # scripts/build_mcpb.py hard-fails if the two drift apart, so both
+            # files have to move together.
             sed -i "s/statuspro-openapi-client>=[0-9.]\\+/statuspro-openapi-client>=$CLIENT_VERSION/" \
-              statuspro_mcp_server/pyproject.toml
-            echo "Updated floor to >=$CLIENT_VERSION"
+              statuspro_mcp_server/pyproject.toml \
+              statuspro_mcp_server/mcpb/pyproject.template.toml
+            echo "Updated floor to >=$CLIENT_VERSION (package + mcpb template)"
           else
             echo "Floor already matches; nothing to do"
           fi
@@ -77,12 +81,14 @@ jobs:
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           set -euo pipefail
-          if git diff --quiet -- uv.lock statuspro_mcp_server/pyproject.toml; then
+          if git diff --quiet -- uv.lock statuspro_mcp_server/pyproject.toml \
+            statuspro_mcp_server/mcpb/pyproject.template.toml; then
             echo "Nothing to commit"
             exit 0
           fi
           git config user.name "dougborg-release-please[bot]"
           git config user.email "309159260+dougborg-release-please[bot]@users.noreply.github.com"
-          git add uv.lock statuspro_mcp_server/pyproject.toml
+          git add uv.lock statuspro_mcp_server/pyproject.toml \
+            statuspro_mcp_server/mcpb/pyproject.template.toml
           git commit -m "chore(release): sync uv.lock and MCP client pin"
           git push origin "HEAD:$HEAD_REF"

--- a/statuspro_mcp_server/mcpb/pyproject.template.toml
+++ b/statuspro_mcp_server/mcpb/pyproject.template.toml
@@ -14,7 +14,7 @@ description = "MCP server for the StatusPro API"
 requires-python = ">=3.12"
 dependencies = [
     "fastmcp>=3.0",
-    "statuspro-openapi-client>=0.1.0",
+    "statuspro-openapi-client>=0.3.0",
     "prefab-ui>=0.19,<0.20",
     "pydantic>=2.12.0",
     "python-dotenv>=1.0.0",


### PR DESCRIPTION
## Problem

Publishing `mcp-v0.2.0` failed in [run 30273452529](https://github.com/dougborg/statuspro-openapi-client/actions/runs/30273452529):

```
RuntimeError: Bundle pyproject.template.toml is out of sync with the package's.
```

`release-pr-prepare.yml` keeps `statuspro_mcp_server/pyproject.toml`'s client floor truthful — it correctly bumped it to `>=0.3.0` on the release PR. But the `.mcpb` bundle carries a **second copy** of the dependency list in `statuspro_mcp_server/mcpb/pyproject.template.toml`, and `scripts/build_mcpb.py` hard-fails when the two disagree. Only one of the two moved.

The drift guard did its job — this is a gap in the release glue, not a bad check.

## Fix

- The pin-sync step now rewrites **both** files, and the commit stages both.
- Corrects the drift already on `main` (template `>=0.1.0` vs package `>=0.3.0`), which is what currently blocks `mcp-v0.2.0` from publishing.

## Sibling repos

`stocktrim-openapi-client` has the same `mcpb/pyproject.template.toml` layout and will hit this identically once its release PR runs. `frontapp` and `katana` have no bundle template and are unaffected.

## Context

Found while recovering the stuck draft releases from #134. `client-v0.3.0` published successfully (PyPI 0.3.0, release un-drafted with wheel, sdist and both attestations attached); `mcp-v0.2.0` is the remaining one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRhJ5dF3N3z7X63aRaDBcQ